### PR TITLE
Add client token module for generating new client tokens

### DIFF
--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -1,0 +1,35 @@
+defmodule Braintree.ClientToken do
+  @moduledoc """
+  Generate a token required by the client SDK to communicate with Braintree.
+
+  For additional reference see:
+  https://developers.braintreepayments.com/reference/request/client-token/generate/ruby
+  """
+
+  alias Braintree.HTTP
+  alias Braintree.ErrorResponse, as: Error
+
+  @doc """
+  Create a client token, or return an error response.
+
+  ## Example
+
+      {:ok, client_token} = Braintree.ClientToken.generate()
+
+      client_token # A new client token
+  """
+  @spec generate(:empty | Map.t) :: {:ok, binary} | {:error, Error.t}
+  def generate(params \\ :empty) do
+    case HTTP.post("client_token", wrap_params(params)) do
+      {:ok, %{"client_token" => client_token}} ->
+        {:ok, client_token["value"]}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+    end
+  end
+
+  defp wrap_params(:empty),
+    do: %{}
+  defp wrap_params(params),
+    do: %{client_token: params}
+end

--- a/test/integration/client_token_test.exs
+++ b/test/integration/client_token_test.exs
@@ -1,0 +1,23 @@
+defmodule Braintree.Integration.ClientToken do
+  use ExUnit.Case, async: true
+
+  @moduletag :integration
+
+  alias Braintree.{ClientToken,Customer}
+
+  test "generate/1 without any params" do
+    {:ok, _client_token} = ClientToken.generate()
+  end
+
+  test "generate/1 with a customer id" do
+    {:ok, customer} = Customer.create()
+    {:ok, client_token} = ClientToken.generate(%{customer_id: customer.id})
+
+    assert client_token
+    assert client_token =~ ~r/.+/
+  end
+
+  test "generate/1 with a bogus customer" do
+    {:error, error} = ClientToken.generate(%{customer_id: "asdfghjkl"})
+  end
+end


### PR DESCRIPTION
Implements a `generate` method comparable to the [Ruby SDK](https://developers.braintreepayments.com/reference/request/client-token/generate/ruby) for creating new client tokens. A client token is required to initialize a client SDK.