### PR TITLE
Extend API Coverage

### DIFF
--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -1,0 +1,175 @@
+defmodule Braintree.PaymentMethod do
+  @moduledoc """
+  Create, update, find and delete payment methods
+  """
+  @type t :: %__MODULE__{
+               bin:                      String.t,
+               card_type:                String.t,
+               cardholder_name:          String.t,
+               commercial:               String.t,
+               country_of_issuance:      String.t,
+               customer_id:              String.t,
+               customer_location:        String.t,
+               debit:                    String.t,
+               default:                  String.t,
+               durbin_regulated:         String.t,
+               expiration_month:         String.t,
+               expiration_year:          String.t,
+               expired:                  String.t,
+               healthcare:               String.t,
+               image_url:                String.t,
+               issuing_bank:             String.t,
+               last_4:                   String.t,
+               payroll:                  String.t,
+               prepaid:                  String.t,
+               token:                    String.t,
+               unique_number_identifier: String.t,
+               created_at:               String.t,
+               updated_at:               String.t,
+               venmo_sdk:                boolean,
+               subscriptions:            [],
+               verifications:            []
+             }
+
+  defstruct bin:                      nil,
+            card_type:                nil,
+            cardholder_name:          nil,
+            commercial:               "Unknown",
+            country_of_issuance:      "Unknown",
+            customer_id:              nil,
+            customer_location:        nil,
+            debit:                    "Unknown",
+            default:                  false,
+            durbin_regulated:         "Unknown",
+            expiration_month:         nil,
+            expiration_year:          nil,
+            expired:                  nil,
+            healthcare:               "Unknown",
+            image_url:                nil,
+            issuing_bank:             "Unknown",
+            last_4:                   nil,
+            payroll:                  "Unknown",
+            prepaid:                  "Unknown",
+            token:                    nil,
+            unique_number_identifier: nil,
+            created_at:               nil,
+            updated_at:               nil,
+            venmo_sdk:                "Unknown",
+            subscriptions:            [],
+            verifications:            []
+
+  alias Braintree.HTTP
+  alias Braintree.CreditCard
+  alias Braintree.ErrorResponse, as: Error
+  import Braintree.Util, only: [atomize: 1]
+
+  @doc """
+  Create a payment method record, or return an error response with after failed
+  validation.
+
+  ## Example
+
+      {:ok, customer} = Braintree.Customer.create(%{
+        first_name: "Jen",
+        last_name: "Smith"
+      })
+      
+      {:ok, credit_card} = Braintree.PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Braintree.Testing.Nonces.transactable
+      })
+      
+      credit_card.type #Visa
+  """
+  @spec create(Map.t) :: {:ok, t} | {:error, Error.t}
+  def create(params \\ %{}) do
+    case HTTP.post("payment_methods", %{payment_method: params}) do
+      {:ok, %{"credit_card" => credit_card}} ->
+        {:ok, construct(credit_card)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+    end
+  end
+  
+  @doc """
+  Update a payment method record, or return an error response with after failed
+  validation.
+
+  ## Example
+
+      {:ok, customer} = Braintree.Customer.create(%{
+        first_name: "Jen",
+        last_name: "Smith"
+      })
+      
+      {:ok, credit_card} = Braintree.PaymentMethod.create(%{
+        customer_id: customer.id,
+        cardholder_name: "CH Name",
+        payment_method_nonce: Braintree.Testing.Nonces.transactable
+      })
+      
+      {:ok, payment_method} = Braintree.PaymentMethod.update(credit_card.token,
+        %{
+          cardholder_name: "NEW"
+        }
+      )
+      
+      payment_method.cardholder_name #NEW
+  """
+  @spec update(String.t, Map.t) :: {:ok, t} | {:error, Error.t}
+  def update(token, params \\ %{}) do
+    case HTTP.put("payment_methods/any/#{token}", %{payment_method: params}) do
+      {:ok, %{"credit_card" => credit_card}} ->
+        {:ok, construct(credit_card)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  
+  
+  @doc """
+  Delete a payment method record, or return an error response if token invalid
+
+  ## Example
+
+      {:ok, message} = Braintree.PaymentMethod.delete(token)
+      message #Success
+  """
+  @spec delete(String.t) :: {:ok, t} | {:error, Error.t}
+  def delete(token) do
+    case HTTP.delete("payment_methods/any/#{token}") do
+      {:ok, %{}} ->
+        {:ok, "Success"}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  
+  @doc """
+  Find a payment method record, or return an error response if token invalid
+
+  ## Example
+
+      {:ok, payment_method} = Braintree.PaymentMethod.find(token)
+      payment_method.type #CreditCard
+  """
+  @spec find(String.t) :: {:ok, t} | {:error, Error.t}
+  def find(token) do
+    case HTTP.get("payment_methods/any/#{token}") do
+      {:ok, %{"credit_card" => credit_card}} ->
+        {:ok, construct(credit_card)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+
+  def construct(map) do
+    struct(__MODULE__, atomize(map))
+  end
+end

--- a/lib/payment_method_nonce.ex
+++ b/lib/payment_method_nonce.ex
@@ -1,0 +1,75 @@
+defmodule Braintree.PaymentMethodNonce do
+  @moduledoc """
+  Create a payment method nonce from an existing payment method token
+  """
+  @type t :: %__MODULE__{
+               default:                  String.t,
+               description:              String.t,
+               nonce:                    String.t,
+               three_d_secure_info:      String.t,
+               type:                     String.t,
+               details:                  Map.t,
+               is_locked:                boolean,
+               consumed:                 boolean,
+               security_questions:       []
+             }
+
+  defstruct default:              nil,
+            description:          nil,
+            nonce:                nil,
+            three_d_secure_info:  nil,
+            type:                 nil,
+            is_locked:            false,
+            details:              nil,
+            consumed:             false,
+            security_questions:   nil
+
+  import Braintree.Util, only: [atomize: 1]
+  alias Braintree.HTTP
+  alias Braintree.ErrorResponse, as: Error
+  
+  @doc """
+  Create a payment method nonce from `token`
+
+  ## Example
+
+      {:ok, payment_method_nonce} = Braintree.PaymentMethodNonce.create(token)
+      
+      payment_method_nonce.nonce
+  """
+  @spec create(String.t) :: {:ok, t} | {:error, Error.t}
+  def create(payment_method_token) do
+    case HTTP.post("payment_methods/#{payment_method_token}/nonces", %{}) do
+      {:ok, %{"payment_method_nonce" => payment_method_nonce}} ->
+        {:ok, construct(payment_method_nonce)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  
+  @doc """
+  Find a payment method nonce, or return an error response if token invalid
+
+  ## Example
+
+      {:ok, payment_method} = Braintree.PaymentMethodNonce.find(token)
+      payment_method.type #CreditCard
+  """
+  @spec find(String.t) :: {:ok, t} | {:error, Error.t}
+  def find(nonce) do
+    case HTTP.get("payment_method_nonces/#{nonce}") do
+      {:ok, %{"payment_method_nonce" => payment_method_nonce}} ->
+        {:ok, construct(payment_method_nonce)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  
+  def construct(map) do
+    struct(__MODULE__, atomize(map))
+  end
+end

--- a/lib/testing/test_transaction.ex
+++ b/lib/testing/test_transaction.ex
@@ -1,0 +1,80 @@
+if Mix.env == :test do
+  defmodule Braintree.Testing.TestTransaction do
+    @moduledoc """
+    Create transasctions for testing purposes only.
+    Transition to settled, settlement_confirmed, or settlement_declined
+    """
+
+    import Braintree.Util, only: [atomize: 1]
+
+    alias Braintree.Transaction
+    alias Braintree.HTTP
+    alias Braintree.ErrorResponse, as: Error
+
+    @doc """
+    Use a `transaction_id` to transition to settled status
+    Allows for testing of refunds
+
+    ## Example
+
+        {:ok, transaction} = TestTransaction.settle(transaction_id: "123")
+
+        transaction.status # "settled"
+    """
+    @spec settle(String.t) :: {:ok, any} | {:error, Error.t}
+    def settle(transaction_id) do
+      case HTTP.put("transactions/#{transaction_id}/settle", %{}) do
+        {:ok, %{"transaction" => transaction}} ->
+          {:ok, Transaction.construct(transaction)}
+        {:error, %{"api_error_response" => error}} ->
+          {:error, Error.construct(error)}
+        {:error, :not_found} ->
+          {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+      end
+    end
+
+    @doc """
+    Use a `transaction_id` to transition to settled_confirmed status
+
+    ## Example
+
+        {:ok, transaction} = TestTransaction.settlement_confirm(
+          transaction_id: "123")
+
+        transaction.status # "settlement_confirmed"
+    """
+    @spec settlement_confirm(String.t) :: {:ok, any} | {:error, Error.t}
+    def settlement_confirm(transaction_id) do
+      case HTTP.put("transactions/#{transaction_id}/settlement_confirm", %{}) do
+        {:ok, %{"transaction" => transaction}} ->
+          {:ok, Transaction.construct(transaction)}
+        {:error, %{"api_error_response" => error}} ->
+          {:error, Error.construct(error)}
+        {:error, :not_found} ->
+          {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+      end
+    end
+
+    @doc """
+    Use a `transaction_id` to transition to settlement_declined status
+
+    ## Example
+
+        {:ok, transaction} = TestTransaction.settlement_decline(
+          transaction_id: "123")
+
+        transaction.status # "settlement_declined"
+    """
+    @spec settlement_decline(String.t) :: {:ok, any} | {:error, Error.t}
+    def settlement_decline(transaction_id) do
+      case HTTP.put("transactions/#{transaction_id}/settlement_decline", %{}) do
+        {:ok, %{"transaction" => transaction}} ->
+          {:ok, Transaction.construct(transaction)}
+        {:error, %{"api_error_response" => error}} ->
+          {:error, Error.construct(error)}
+        {:error, :not_found} ->
+          {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+      end
+    end
+  end
+end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -85,7 +85,72 @@ defmodule Braintree.Transaction do
         {:error, Error.construct(error)}
     end
   end
+  
+  
+  @doc """
+  Use a `transaction_id` and optional `amount` to issue a refund
+  for that transaction
 
+  ## Example
+
+      {:ok, transaction} = Transaction.refund(
+      "123",
+      %{
+        amount: "100.00"
+      })
+
+      transaction.status # "refunded"
+  """
+  @spec refund(String.t, Map.t) :: {:ok, any} | {:error, Error.t}
+  def refund(transaction_id, params) do
+    case HTTP.post("transactions/#{transaction_id}/refund", %{transaction: params}) do
+      {:ok, %{"transaction" => transaction}} ->
+        {:ok, construct(transaction)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+    end
+  end
+  
+  @doc """
+  Use a `transaction_id` to issue a void for that transaction
+
+  ## Example
+
+      {:ok, transaction} = Transaction.void("123")
+
+      transaction.status # "voided"
+  """
+  @spec void(String.t) :: {:ok, any} | {:error, Error.t}
+  def void(transaction_id) do
+    case HTTP.put("transactions/#{transaction_id}/void", %{}) do
+      {:ok, %{"transaction" => transaction}} ->
+        {:ok, construct(transaction)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+    end
+  end
+  
+  @doc """
+  Find an existing transaction by `transaction_id`
+
+  ## Example
+
+      {:ok, transaction} = Transaction.find("123")
+  """
+  @spec find(String.t) :: {:ok, any} | {:error, Error.t}
+  def find(transaction_id) do
+    case HTTP.get("transactions/#{transaction_id}") do
+      {:ok, %{"transaction" => transaction}} ->
+        {:ok, construct(transaction)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+    end
+  end
+  
   def construct(map) do
     struct(__MODULE__, atomize(map))
   end

--- a/test/integration/payment_method_nonce_test.exs
+++ b/test/integration/payment_method_nonce_test.exs
@@ -1,0 +1,62 @@
+defmodule Braintree.Integration.PaymentMethodNonceTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.Customer
+  alias Braintree.PaymentMethodNonce
+  alias Braintree.Testing.CreditCardNumbers
+
+  @moduletag :integration
+
+  test "create/1 throws error message when provided invalid token" do
+    {:error, error} = PaymentMethodNonce.create("invalid_token")
+
+    assert error.message == "Token is invalid."
+  end
+
+  test "create/1 succeeds when provided valid token" do
+    {:ok, customer} = Customer.create(
+      first_name: "Rick",
+      last_name: "Grimes",
+      credit_card: %{
+        number: master_card,
+        expiration_date: "01/2016",
+        cvv: "100"
+      }
+    )
+
+    [card] = customer.credit_cards
+    {:ok, payment_method_nonce} = PaymentMethodNonce.create(card.token)
+
+    assert payment_method_nonce.type == "CreditCard"
+  end
+
+  test "find/1 fails when invalid nonce provided" do
+    {:error, error} = PaymentMethodNonce.find("bogus")
+
+    assert error.message == "Token is invalid."
+  end
+
+  test "find/1 succeeds when valid token provided" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Rick",
+      last_name: "Grimes",
+      credit_card: %{
+        number: master_card,
+        expiration_date: "01/2016",
+        cvv: "100"
+      }
+    })
+
+    [card] = customer.credit_cards
+    {:ok, payment_method_nonce} = PaymentMethodNonce.create(card.token)
+
+    {:ok, found_nonce} = PaymentMethodNonce.find(payment_method_nonce.nonce)
+
+    assert found_nonce.type == payment_method_nonce.type
+    assert found_nonce.nonce == payment_method_nonce.nonce
+  end
+
+  defp master_card do
+    CreditCardNumbers.master_cards() |> List.first
+  end
+end

--- a/test/integration/payment_method_test.exs
+++ b/test/integration/payment_method_test.exs
@@ -1,0 +1,147 @@
+defmodule Braintree.Integration.PaymentMethodTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.Customer
+  alias Braintree.PaymentMethod
+  alias Braintree.PaymentMethodNonce
+  alias Braintree.Testing.Nonces
+  alias Braintree.Testing.CreditCardNumbers
+  
+  @moduletag :integration
+
+  test "create/1 fails when customer_id not provided" do
+    {:error, error} = PaymentMethod.create(%{
+      payment_method_nonce: Nonces.transactable
+    })
+
+    assert error.message == "Customer ID is required."
+  end
+
+  test "create/1 fails when payment_method_nonce not provided" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:error, error} = PaymentMethod.create(%{
+      customer_id: customer.id
+    })
+
+    assert error.message == "Nonce is required."
+  end
+
+  test "create/1 can create a payment method from an existing customer and fake nonce" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.transactable
+      })
+
+    assert payment_method.card_type == "Visa"
+    assert payment_method.bin =~ ~r/^\w+$/
+  end
+
+  test "create/1 can create a payment method from a vaulted credit card nonce" do
+    {:ok, customer} = Customer.create(
+      first_name: "Rick",
+      last_name: "Grimes",
+      credit_card: %{
+        number: master_card,
+        expiration_date: "01/2016",
+        cvv: "100"
+      }
+    )
+
+    [card] = customer.credit_cards
+    {:ok, payment_method_nonce} = PaymentMethodNonce.create(card.token)
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: payment_method_nonce.nonce
+      })
+
+    assert payment_method.card_type == "MasterCard"
+    assert payment_method.bin =~ card.bin
+  end
+
+  test "update/1 fails when invalid token provided" do
+    {:error, error} = PaymentMethod.update("bogus")
+
+    assert error.message == "Token is invalid."
+  end
+
+  test "update/2 can successfully update existing payment_method" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        cardholder_name: "Bruce",
+        payment_method_nonce: Nonces.transactable
+      })
+
+    assert payment_method.cardholder_name == "Bruce"
+
+    {:ok, updated_payment_method} = PaymentMethod.update(payment_method.token, %{
+        cardholder_name: "Steve"
+      })
+
+    assert updated_payment_method.cardholder_name == "Steve"
+  end
+
+  test "delete/1 fails when invalid token provided" do
+    {:error, error} = PaymentMethod.delete("bogus")
+
+    assert error.message == "Token is invalid."
+  end
+
+  test "delete/1 succeeds when valid token provided" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.transactable
+      })
+
+    {:ok, message} = PaymentMethod.delete(payment_method.token)
+
+    assert message == "Success"
+  end
+
+  test "find/1 fails when invalid token provided" do
+    {:error, error} = PaymentMethod.find("bogus")
+
+    assert error.message == "Token is invalid."
+  end
+
+  test "find/1 succeeds when valid token provided" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.transactable
+      })
+
+    {:ok, found_payment} = PaymentMethod.find(payment_method.token)
+
+    assert found_payment.cardholder_name == payment_method.cardholder_name
+    assert found_payment.card_type == payment_method.card_type
+    assert found_payment.token == payment_method.token
+  end
+
+  defp master_card do
+    CreditCardNumbers.master_cards() |> List.first
+  end
+end

--- a/test/integration/subscription_test.exs
+++ b/test/integration/subscription_test.exs
@@ -8,7 +8,7 @@ defmodule Braintree.Integration.SubscriptionTest do
 
   test "create/1 with a plan_id" do
     assert {:ok, customer} = Customer.create(%{payment_method_nonce: "fake-valid-nonce"})
-    card = customer.credit_cards |> List.first
+    [card] = customer.credit_cards
     assert {:ok, _subscription } = Subscription.create(%{payment_method_token: card.token, plan_id: "starter"})
   end
 end

--- a/test/integration/test_transaction_test.exs
+++ b/test/integration/test_transaction_test.exs
@@ -1,0 +1,102 @@
+defmodule Braintree.Integration.TestTransactionTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.Transaction
+  alias Braintree.Testing.Nonces
+  alias Braintree.Testing.TestTransaction
+
+  @moduletag :integration
+
+  test "settle/1 succeeds if sale has been submitted for settlement" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment,
+      options: %{submit_for_settlement: true}
+    })
+
+    {:ok, settle_transaction} = TestTransaction.settle(transaction.id)
+
+    assert settle_transaction.status == "settled"
+  end
+
+  test "settle/1 fails if sale is authorized only" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    {:error, error} = TestTransaction.settle(transaction.id)
+
+    assert error.message == "Cannot transition transaction to settled, settlement_confirmed, or settlement_declined"
+    refute error.params == %{}
+    refute error.errors == %{}
+  end
+
+  test "settle/1 fails if transaction id is invalid" do
+    {:error, error} = TestTransaction.settle("bogus")
+
+    assert error.message == "Transaction ID is invalid."
+  end
+
+  test "settle_confirm/1 fails if sale is authorized only" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    {:error, error} = TestTransaction.settlement_confirm(transaction.id)
+
+    assert error.message == "Cannot transition transaction to settled, settlement_confirmed, or settlement_declined"
+    refute error.params == %{}
+    refute error.errors == %{}
+  end
+
+  test "settlement_confirm/1 fails if transaction id is invalid" do
+    {:error, error} = TestTransaction.settlement_confirm("bogus")
+
+    assert error.message == "Transaction ID is invalid."
+  end
+
+  test "settlement_confirm/1 succeeds if sale has been submit for settlement" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment,
+      options: %{submit_for_settlement: true}
+    })
+
+    {:ok, settle_transaction} = TestTransaction.settlement_confirm(transaction.id)
+
+    assert settle_transaction.status == "settlement_confirmed"
+  end
+
+  test "settlement_decline/1 fails if sale is authorized only" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    {:error, error} = TestTransaction.settlement_decline(transaction.id)
+
+    assert error.message == "Cannot transition transaction to settled, settlement_confirmed, or settlement_declined"
+    refute error.params == %{}
+    refute error.errors == %{}
+  end
+
+  test "settlement_decline/1 fails if transaction id is invalid" do
+    {:error, error} = TestTransaction.settlement_decline("bogus")
+
+    assert error.message == "Transaction ID is invalid."
+  end
+  
+  test "settlement_decline/1 succeeds if sale has been submit for settlement" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment,
+      options: %{submit_for_settlement: true}
+    })
+
+    {:ok, settle_transaction} = TestTransaction.settlement_decline(transaction.id)
+
+    assert settle_transaction.status == "settlement_declined"
+  end
+end

--- a/test/integration/transaction_test.exs
+++ b/test/integration/transaction_test.exs
@@ -3,6 +3,7 @@ defmodule Braintree.Integration.TransactionTest do
 
   alias Braintree.Transaction
   alias Braintree.Testing.Nonces
+  alias Braintree.Testing.TestTransaction
 
   @moduletag :integration
 
@@ -18,7 +19,18 @@ defmodule Braintree.Integration.TransactionTest do
     assert transaction.id =~ ~r/^\w+$/
   end
 
-  test "sale/1 failes with an invalid amount" do
+  test "sale/1 status is authorized when not submit for settlement" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    assert transaction.amount == "100.00"
+    assert transaction.status == "authorized"
+    assert transaction.id =~ ~r/^\w+$/
+  end
+
+  test "sale/1 fails with an invalid amount" do
     {:error, error} = Transaction.sale(%{
       amount: "2000.00",
       payment_method_nonce: Nonces.paypal_one_time_payment,
@@ -28,5 +40,67 @@ defmodule Braintree.Integration.TransactionTest do
     assert error.message == "Do Not Honor"
     refute error.params == %{}
     refute error.errors == %{}
+  end
+
+  test "refund/2 fails if sale is not yet settled" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    {:error, error}  = Transaction.refund(transaction.id, %{amount: "100.00"})
+    
+    assert error.message == "Cannot refund a transaction unless it is settled."
+    refute error.params == %{}
+    refute error.errors == %{}
+  end
+
+  test "refund/2 succeeds if sale is has been settled" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment,
+      options: %{submit_for_settlement: true}
+    })
+
+    {:ok, _} = TestTransaction.settle(transaction.id)
+    {:ok, refund} = Transaction.refund(transaction.id, %{amount: "100.00"})
+
+    assert refund.refunded_transaction_id =~ ~r/^\w+$/
+    assert refund.amount == "100.00"
+  end
+
+  test "void/1 succeeds for previous sale transaction" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    {:ok, void}  = Transaction.void(transaction.id)
+
+    assert void.status == "voided"
+  end
+
+  test "void/1 fails for invalid transaction id" do
+    {:error, error}  = Transaction.void("bogus")
+
+    assert error.message == "Transaction ID is invalid."
+  end
+
+  test "find/1 fails for invalid transaction id" do
+    {:error, error}  = Transaction.find("bogus")
+
+    assert error.message == "Transaction ID is invalid."
+  end
+
+  test "find/1 suceeds for existing transaction" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+
+    {:ok, found_transaction}  = Transaction.find(transaction.id)
+
+    assert found_transaction.status == transaction.status
+    assert found_transaction.amount == transaction.amount
   end
 end


### PR DESCRIPTION
@sorentwo This PR adds API hooks for the following:

#### Transaction
- void
- refund
- find

#### PaymentMethod
- create
- update
- find
- delete

#### PaymentMethodNonce
- create
- find

I'm totally open to suggestions/criticism. I tried to stay consistent with existing patterns and naming conventions. If this gets the 👍  I might hit you with a follow up PR that beefs up testing around PaymentMethod... the current [Ruby SDK](https://github.com/braintree/braintree_ruby/blob/c35917379a33de405b7a47eb9f83b7f732255262/spec/integration/braintree/payment_method_spec.rb) has some pretty heavy testing.