### PR TITLE
Add Support for PayPal Vault Flow

### DIFF
--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -59,6 +59,7 @@ defmodule Braintree.PaymentMethod do
             verifications:            []
 
   alias Braintree.HTTP
+  alias Braintree.PaypalAccount
   alias Braintree.ErrorResponse, as: Error
   import Braintree.Util, only: [atomize: 1]
 
@@ -85,6 +86,8 @@ defmodule Braintree.PaymentMethod do
     case HTTP.post("payment_methods", %{payment_method: params}) do
       {:ok, %{"credit_card" => credit_card}} ->
         {:ok, construct(credit_card)}
+      {:ok, %{"paypal_account" => paypal_account}} ->
+        {:ok, PaypalAccount.construct(paypal_account)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
     end
@@ -120,6 +123,8 @@ defmodule Braintree.PaymentMethod do
     case HTTP.put("payment_methods/any/#{token}", %{payment_method: params}) do
       {:ok, %{"credit_card" => credit_card}} ->
         {:ok, construct(credit_card)}
+      {:ok, %{"paypal_account" => paypal_account}} ->
+        {:ok, PaypalAccount.construct(paypal_account)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
       {:error, :not_found} -> 
@@ -161,6 +166,8 @@ defmodule Braintree.PaymentMethod do
     case HTTP.get("payment_methods/any/#{token}") do
       {:ok, %{"credit_card" => credit_card}} ->
         {:ok, construct(credit_card)}
+      {:ok, %{"paypal_account" => paypal_account}} ->
+        {:ok, PaypalAccount.construct(paypal_account)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
       {:error, :not_found} -> 

--- a/lib/paypal_account.ex
+++ b/lib/paypal_account.ex
@@ -1,0 +1,98 @@
+defmodule Braintree.PaypalAccount do
+  @moduledoc """
+  Find, update and delete Paypal Accounts using PaymentMethod token
+  """
+  alias Braintree.HTTP
+  alias Braintree.ErrorResponse, as: Error
+  import Braintree.Util, only: [atomize: 1]
+
+  @type t :: %__MODULE__{
+               billing_agreement_id:      String.t,
+               created_at:                String.t,
+               customer_id:               String.t,
+               email:                     String.t,
+               image_url:                 String.t,
+               payer_info:                String.t,
+               token:                     String.t,
+               updated_at:                String.t,
+               default:                   boolean,
+               is_channel_initated:       boolean,
+               subscriptions:             []
+             }
+
+  defstruct billing_agreement_id:         nil,
+            created_at:                   nil,
+            customer_id:                  nil,
+            email:                        nil,
+            image_url:                    nil,
+            payer_info:                   nil,
+            token:                        nil,
+            updated_at:                   nil,
+            default:                      false,
+            is_channel_initated:          false,
+            subscriptions:                []
+  @doc """
+  Find a paypal account record using `token`
+  or return an error response if token invalid
+
+  ## Example
+
+      {:ok, paypal_account} = Braintree.PaypalAccount.find(token)
+  """
+  @spec find(String.t) :: {:ok, t} | {:error, Error.t}
+  def find(token) do
+    case HTTP.get("payment_methods/paypal_account/#{token}") do
+      {:ok, %{"paypal_account" => paypal_account}} ->
+        {:ok, construct(paypal_account)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  
+  @doc """
+  Update a paypal account record using `token`
+  or return an error response if token invalid
+
+  ## Example
+
+      {:ok, paypal_account} = Braintree.PaypalAccount.update(token, %{
+        options: %{make_default: true})
+      paypal_account.email #test@test.com
+  """
+  @spec update(String.t, Map.t) :: {:ok, t} | {:error, Error.t}
+  def update(token, params) do
+    case HTTP.put("payment_methods/paypal_account/#{token}", %{paypal_account: params}) do
+      {:ok, %{"paypal_account" => paypal_account}} ->
+        {:ok, construct(paypal_account)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  
+  @doc """
+  Delete a paypal account record using `token`
+  or return an error response if token invalid
+
+  ## Example
+
+      {:ok, paypal_account} = Braintree.PaypalAccount.delete(token)
+  """
+  @spec delete(String.t) :: {:ok, t} | {:error, Error.t}
+  def delete(token) do
+    case HTTP.delete("payment_methods/paypal_account/#{token}") do
+      {:ok, %{}} ->
+        {:ok, "Success"}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+      {:error, :not_found} -> 
+        {:error, Error.construct(%{"message" => "Token is invalid."})}
+    end
+  end
+  def construct(map) do
+    struct(__MODULE__, atomize(map))
+  end
+end

--- a/test/integration/payment_method_test.exs
+++ b/test/integration/payment_method_test.exs
@@ -68,6 +68,36 @@ defmodule Braintree.Integration.PaymentMethodTest do
     assert payment_method.bin =~ card.bin
   end
 
+  test "create/1 can create a paypal payment method" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Rick",
+      last_name: "Grimes"
+    })
+    
+    {:ok, paypal_account} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.paypal_future_payment
+      })
+      
+    assert paypal_account.email == "jane.doe@example.com"
+    assert paypal_account.token =~ ~r/^\w+$/
+  end
+
+  test "create/1 can successfully make paypal payment method the default" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+    
+    {:ok, paypal_account} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.paypal_future_payment,
+        options: %{make_default: true}
+      })
+      
+    assert paypal_account.default == true
+  end
+
   test "update/1 fails when invalid token provided" do
     {:error, error} = PaymentMethod.update("bogus")
 
@@ -94,6 +124,22 @@ defmodule Braintree.Integration.PaymentMethodTest do
 
     assert updated_payment_method.cardholder_name == "Steve"
   end
+  
+  test "update/2 can successfully call update on paypal payment method" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, paypal_account} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.paypal_future_payment
+      })
+
+    {:ok, updated_paypal_account} = PaymentMethod.update(paypal_account.token, %{})
+
+    assert updated_paypal_account.email == "jane.doe@example.com"
+  end
 
   test "delete/1 fails when invalid token provided" do
     {:error, error} = PaymentMethod.delete("bogus")
@@ -113,6 +159,22 @@ defmodule Braintree.Integration.PaymentMethodTest do
       })
 
     {:ok, message} = PaymentMethod.delete(payment_method.token)
+
+    assert message == "Success"
+  end
+  
+  test "delete/1 can delete paypal payment method" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, paypal_account} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.paypal_future_payment
+      })
+      
+    {:ok, message} = PaymentMethod.delete(paypal_account.token)
 
     assert message == "Success"
   end
@@ -139,6 +201,23 @@ defmodule Braintree.Integration.PaymentMethodTest do
     assert found_payment.cardholder_name == payment_method.cardholder_name
     assert found_payment.card_type == payment_method.card_type
     assert found_payment.token == payment_method.token
+  end
+  
+  test "find/1 can find an existing paypal payment method" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Bill",
+      last_name: "Gates"
+    })
+
+    {:ok, paypal_account} = PaymentMethod.create(%{
+        customer_id: customer.id,
+        payment_method_nonce: Nonces.paypal_future_payment
+      })
+
+    {:ok, found_paypal_account} = PaymentMethod.find(paypal_account.token)
+    
+    assert found_paypal_account.email == "jane.doe@example.com"
+    assert found_paypal_account.token =~ ~r/^\w+$/
   end
 
   defp master_card do

--- a/test/integration/paypal_account_test.exs
+++ b/test/integration/paypal_account_test.exs
@@ -1,0 +1,75 @@
+defmodule Braintree.Integration.PaypalAccountTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.PaypalAccount
+  alias Braintree.Customer
+  alias Braintree.PaymentMethod
+  alias Braintree.Testing.Nonces
+
+  test "find/1 can successfully find a paypal account" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Test",
+      last_name: "User"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+      customer_id: customer.id,
+      payment_method_nonce: Nonces.paypal_future_payment
+    })
+    
+    {:ok, paypal_account} = PaypalAccount.find(payment_method.token)
+    assert paypal_account.email == "jane.doe@example.com"
+    assert paypal_account.token =~ ~r/^\w+$/
+  end
+
+  test "find/1 fails with an invalid token" do
+    {:error, error} = PaypalAccount.find("bogus")
+    
+    assert error.message == "Token is invalid."
+  end
+  
+  test "update/2 can successfully update a paypal account" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Test",
+      last_name: "User"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+      customer_id: customer.id,
+      payment_method_nonce: Nonces.paypal_future_payment
+    })
+    
+    {:ok, paypal_account} = PaypalAccount.update(payment_method.token, %{
+      options: %{make_default: true}
+      })
+    assert paypal_account.default == true
+  end
+  
+  test "update/2 fails with an invalid token" do
+    {:error, error} = PaypalAccount.update("bogus", %{})
+    
+    assert error.message == "Token is invalid."
+  end
+  
+  test "delete/1 can successfully delete a paypal account" do
+    {:ok, customer} = Customer.create(%{
+      first_name: "Test",
+      last_name: "User"
+    })
+
+    {:ok, payment_method} = PaymentMethod.create(%{
+      customer_id: customer.id,
+      payment_method_nonce: Nonces.paypal_future_payment
+    })
+    
+    {:ok, message} = PaypalAccount.delete(payment_method.token)
+    
+    assert message == "Success"
+  end
+  
+  test "delete/1 fails with an invalid token" do
+    {:error, error} = PaypalAccount.delete("bogus")
+    
+    assert error.message == "Token is invalid."
+  end
+end


### PR DESCRIPTION
This adds support for PayPal payment methods for use with Braintree's PayPal Vault Flow.

#### PaypalAccount
- Find
- Update
- Delete

#### PaymentMethod
- Create, Find, Update now respond to ```{:ok, %{"paypal_account" => paypal_account}}``` response tuple.