### PR TITLE
add submit_for_settlement/2 method

### DIFF
--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -148,8 +148,9 @@ defmodule Braintree.Transaction do
   Use this if `submit_for_settlement` was false while creating the charge using sale.
 
   ## Example
+
       {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
-      transaction.status # 'settling'
+      transaction.status # "settling"
   """
   @spec submit_for_settlement(String.t, Map.t) :: {:ok, any} | {:error, Error.t}
   def submit_for_settlement(transaction_id, params) do

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -152,7 +152,7 @@ defmodule Braintree.Transaction do
       {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
       transaction.status # "settling"
   """
-  @spec submit_for_settlement(String.t, Map.t) :: {:ok, any} | {:error, Error.t}
+  @spec submit_for_settlement(String.t, Map.t) :: {:ok, t} | {:error, Error.t}
   def submit_for_settlement(transaction_id, params) do
     case HTTP.put("transactions/#{transaction_id}/submit_for_settlement", %{transaction: params}) do
       {:ok, %{"transaction" => transaction}} ->

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -143,6 +143,23 @@ defmodule Braintree.Transaction do
     end
   end
 
+  @doc """
+  Use a `transaction_id` and optional `amount` to settle the transaction.
+  Use this if `submit_for_settlement` was false while creating the charge using sale.
+
+  ## Example
+      {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
+      transaction.status # 'settling'
+  """
+  @spec submit_for_settlement(String.t, Map.t) :: {:ok, any} | {:error, Error.t}
+  def submit_for_settlement(transaction_id, params) do
+    case HTTP.put("transactions/#{transaction_id}/submit_for_settlement", %{transaction: params}) do
+      {:ok, %{"transaction" => transaction}} ->
+        {:ok, construct(transaction)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+    end
+  end
 
   @doc """
   Use a `transaction_id` and optional `amount` to issue a refund

--- a/test/integration/transaction_test.exs
+++ b/test/integration/transaction_test.exs
@@ -30,6 +30,50 @@ defmodule Braintree.Integration.TransactionTest do
     assert transaction.id =~ ~r/^\w+$/
   end
 
+  test "submit_for_settlement/2 can be used if transaction is authorized but not settling" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+    {:ok, settled_transaction} = Transaction.submit_for_settlement(transaction.id, %{})
+
+    assert settled_transaction.status == "settling"
+  end
+
+  test "submit_for_settlement/2 fails if transaction is already settling" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment,
+      options: %{submit_for_settlement: true}
+    })
+    {:error, error} = Transaction.submit_for_settlement(transaction.id, %{})
+
+    assert error.message == "Cannot submit for settlement unless status is authorized."
+  end
+
+  test "submit_for_settlement/2 can be used for partial settlement" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+    {:ok, settled_transaction} = Transaction.submit_for_settlement(transaction.id, %{amount: "55.00"})
+
+    refute transaction.amount == settled_transaction.amount
+    assert transaction.amount == "100.00"
+    assert settled_transaction.amount == "55.00"
+  end
+
+  test "submit_for_settlement/2 fails if partial settlement amount greater than charged amount" do
+    {:ok, transaction} = Transaction.sale(%{
+      amount: "100.00",
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+    {:error, error} = Transaction.submit_for_settlement(transaction.id, %{amount: "101.00"})
+
+    assert transaction.amount == "100.00"
+    assert error.message == "Settlement amount is too large."
+  end
+
   test "sale/1 fails with an invalid amount" do
     {:error, error} = Transaction.sale(%{
       amount: "2000.00",

--- a/test/integration/transaction_test.exs
+++ b/test/integration/transaction_test.exs
@@ -48,7 +48,7 @@ defmodule Braintree.Integration.TransactionTest do
     })
     {:error, error} = Transaction.submit_for_settlement(transaction.id, %{})
 
-    assert error.message == "Cannot submit for settlement unless status is authorized."
+    assert error.message =~ "Cannot submit for settlement unless status is authorized."
   end
 
   test "submit_for_settlement/2 by default will settle the amount charged" do
@@ -81,7 +81,7 @@ defmodule Braintree.Integration.TransactionTest do
     })
     {:error, error} = Transaction.submit_for_settlement(transaction.id, %{amount: "101.00"})
 
-    assert error.message == "Settlement amount is too large."
+    assert error.message =~ "Settlement amount is too large."
   end
 
   test "sale/1 fails with an invalid amount" do

--- a/test/integration/transaction_test.exs
+++ b/test/integration/transaction_test.exs
@@ -51,6 +51,17 @@ defmodule Braintree.Integration.TransactionTest do
     assert error.message == "Cannot submit for settlement unless status is authorized."
   end
 
+  test "submit_for_settlement/2 by default will settle the amount charged" do
+    amount_charged = "100.00"
+    {:ok, transaction} = Transaction.sale(%{
+      amount: amount_charged,
+      payment_method_nonce: Nonces.paypal_one_time_payment
+    })
+    {:ok, settled_transaction} = Transaction.submit_for_settlement(transaction.id, %{})
+
+    assert settled_transaction.amount == amount_charged
+  end
+
   test "submit_for_settlement/2 can be used for partial settlement" do
     {:ok, transaction} = Transaction.sale(%{
       amount: "100.00",
@@ -70,7 +81,6 @@ defmodule Braintree.Integration.TransactionTest do
     })
     {:error, error} = Transaction.submit_for_settlement(transaction.id, %{amount: "101.00"})
 
-    assert transaction.amount == "100.00"
     assert error.message == "Settlement amount is too large."
   end
 


### PR DESCRIPTION
Adds support for making settlements at a later time, if the option for settlement was false while creating the charge.