### PR TITLE
add xmerl to applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Braintree.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison]]
+    [applications: [:logger, :httpoison, :xmerl]]
   end
 
   defp description do


### PR DESCRIPTION
this adds `xmerl` to the applications list. without it, xmerl is missing in (exrm-)releases. 