### PR TITLE
Add Configurable HTTPoison Timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ config :braintree,
 Furthermore, the environment defaults ot `:sandbox`, so you'll want to configure
 it with `:production` in `prod.exs`.
 
+You can optionally configure HTTPoison timeouts with:
+
+```elixir
+config :braintree,
+  timeout: 8000,     # default, in milliseconds
+  recv_timeout: 5000 # default, in milliseconds
+```
+
 ## Usage
 
 The online [documentation][doc] for Ruby/Java/Python etc. will give you a

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -38,9 +38,9 @@ defmodule Braintree.HTTP do
     {"Content-Type", "application/xml"}
   ]
 
-  @timeout Braintree.get_env(:timeout, 8000) # HTTPoison default
+  @timeout 8000 # (mirrors HTTPoison default)
 
-  @recv_timeout Braintree.get_env(:recv_timeout, 5000) # HTTPoison default
+  @recv_timeout 5000 # (mirrors HTTPoison default)
 
   @doc """
   Centralized request handling function. All convenience structs use this
@@ -123,7 +123,7 @@ defmodule Braintree.HTTP do
     path = Path.join(:code.priv_dir(:braintree), @cacertfile)
 
     [hackney: [ssl_options: [cacertfile: path]],
-     timeout: @timeout,
-     recv_timeout: @recv_timeout]
+     timeout: Braintree.get_env(:timeout, @timeout),
+     recv_timeout: Braintree.get_env(:recv_timeout, @recv_timeout)]
   end
 end

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -117,7 +117,13 @@ defmodule Braintree.HTTP do
 
   defp base_options do
     path = Path.join(:code.priv_dir(:braintree), @cacertfile)
+    timeout = Braintree.get_env(:timeout, 8000) # HTTPoison default
+    recv_timeout = Braintree.get_env(:recv_timeout, 5000) # HTTPoison default
 
-    [hackney: [ssl_options: [cacertfile: path]]]
+    [
+      hackney: [ssl_options: [cacertfile: path]],
+      timeout: timeout,
+      recv_timeout: recv_timeout
+    ]
   end
 end

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -38,6 +38,10 @@ defmodule Braintree.HTTP do
     {"Content-Type", "application/xml"}
   ]
 
+  @timeout Braintree.get_env(:timeout, 8000) # HTTPoison default
+
+  @recv_timeout Braintree.get_env(:recv_timeout, 5000) # HTTPoison default
+
   @doc """
   Centralized request handling function. All convenience structs use this
   function to interact with the Braintree servers. This function can be used
@@ -117,13 +121,9 @@ defmodule Braintree.HTTP do
 
   defp base_options do
     path = Path.join(:code.priv_dir(:braintree), @cacertfile)
-    timeout = Braintree.get_env(:timeout, 8000) # HTTPoison default
-    recv_timeout = Braintree.get_env(:recv_timeout, 5000) # HTTPoison default
 
-    [
-      hackney: [ssl_options: [cacertfile: path]],
-      timeout: timeout,
-      recv_timeout: recv_timeout
-    ]
+    [hackney: [ssl_options: [cacertfile: path]],
+     timeout: @timeout,
+     recv_timeout: @recv_timeout]
   end
 end


### PR DESCRIPTION
While Braintree is generally fast for credit card processing, the PayPal sandbox is often slower than the [relatively] low HTTPoison defaults.  This adds the ability to override (or keep) the timeout parameters.