### PR TITLE
Braintree is returning some odd responses on occasion.  Disable gzip …

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -33,7 +33,6 @@ defmodule Braintree.HTTP do
   @headers [
     {"Accept", "application/xml"},
     {"User-Agent", "Braintree Elixir/0.1"},
-    {"Accept-Encoding", "gzip"},
     {"X-ApiVersion", "4"},
     {"Content-Type", "application/xml"}
   ]
@@ -92,11 +91,10 @@ defmodule Braintree.HTTP do
   @doc false
   def process_response_body(body) do
     body
-    |> :zlib.gunzip
     |> String.strip
     |> XML.load
   rescue
-    ErlangError -> Logger.error("unprocessable response")
+    ErlangError -> Logger.error("unprocessable response: #{body}")
   end
 
   @doc false


### PR DESCRIPTION
…as a potential source of error for now and log the body.