### PR TITLE
Top level elements with attributes break the XML parser

### DIFF
--- a/lib/xml.ex
+++ b/lib/xml.ex
@@ -84,7 +84,7 @@ defmodule Braintree.XML do
       |> parse
 
     case attributes do
-      [type: type] -> %{name => transform({attributes, values})}
+      [attribute] -> %{name => transform({attributes, values})}
       _ -> %{name => transform(values)}
     end
   end

--- a/test/xml_test.exs
+++ b/test/xml_test.exs
@@ -27,6 +27,86 @@ defmodule Braintree.XMLTest do
       %{"customer" => %{"company" => "Soren", "name" => "Parker"}}
   end
 
+  test "load/1 with top level array" do
+    xml = """
+      <plans type="array">
+        <plan>
+            <id>1</id>
+            <merchant-id>2</merchant-id>
+            <billing-day-of-month nil="true"/>
+            <billing-frequency type="integer">1</billing-frequency>
+            <currency-iso-code>USD</currency-iso-code>
+            <description>Simple Plan</description>
+            <name>Simple Plan</name>
+            <number-of-billing-cycles nil="true"/>
+            <price>24.99</price>
+            <trial-duration nil="true"/>
+            <trial-duration-unit nil="true"/>
+            <trial-period type="boolean">false</trial-period>
+            <created-at type="datetime">2016-07-07T01:49:36Z</created-at>
+            <updated-at type="datetime">2016-07-07T01:49:36Z</updated-at>
+            <add-ons type="array"/>
+            <discounts type="array"/>
+        </plan>
+        <plan>
+            <id>1</id>
+            <merchant-id>2</merchant-id>
+            <billing-day-of-month nil="true"/>
+            <billing-frequency type="integer">1</billing-frequency>
+            <currency-iso-code>USD</currency-iso-code>
+            <description>Simple Plan</description>
+            <name>Simple Plan</name>
+            <number-of-billing-cycles nil="true"/>
+            <price>24.99</price>
+            <trial-duration nil="true"/>
+            <trial-duration-unit nil="true"/>
+            <trial-period type="boolean">false</trial-period>
+            <created-at type="datetime">2016-07-07T01:49:36Z</created-at>
+            <updated-at type="datetime">2016-07-07T01:49:36Z</updated-at>
+            <add-ons type="array"/>
+            <discounts type="array"/>
+        </plan>
+      </plans>
+    """
+
+    assert load(xml) == %{
+      "plans" => [
+        %{
+          "add_ons" => [],
+          "billing_day_of_month" => nil,
+          "billing_frequency" => 1,
+          "created_at" => "2016-07-07T01:49:36Z",
+          "currency_iso_code" => "USD",
+          "description" => "Simple Plan",
+          "discounts" => [], "id" => "1",
+          "merchant_id" => "2",
+          "name" => "Simple Plan",
+          "number_of_billing_cycles" => nil,
+          "price" => "24.99",
+          "trial_duration" => nil,
+          "trial_duration_unit" => nil,
+          "trial_period" => false,
+          "updated_at" => "2016-07-07T01:49:36Z"
+        }, %{
+          "add_ons" => [],
+          "billing_day_of_month" => nil,
+          "billing_frequency" => 1,
+          "created_at" => "2016-07-07T01:49:36Z",
+          "currency_iso_code" => "USD",
+          "description" => "Simple Plan",
+          "discounts" => [],
+          "id" => "1",
+          "merchant_id" => "2",
+          "name" => "Simple Plan",
+          "number_of_billing_cycles" => nil,
+          "price" => "24.99",
+          "trial_duration" => nil,
+          "trial_duration_unit" => nil,
+          "trial_period" => false,
+          "updated_at" => "2016-07-07T01:49:36Z"}
+        ]}
+  end
+
   test "load/1 with typed values" do
     xml = """
       <customer>


### PR DESCRIPTION
Hi,

Thanks so much for making this library. I'm really enjoying the API in general. Today I thought I'd add `Plans.all` from the Braintree API to our fork (in the hope of submitting a PR to you), but found that the plans XML response from braintree breaks your XML parser. The plans response looks like the one I have added in the tests and the top level element is an array.

This PR contains what I'd consider to be a pretty hacked on solution that adds a bunch of matchers for transform with 2 arguments and it checks for attributes on the top level element before starting to parse the XML, but I thought at least submitting this PR could start a discussion 😄  I felt I didn't have the time to look into refactoring your solution so I've done what I can to at least zero in on where the issue is.

Thanks! :smile: