### PR TITLE
Add Plan.all support

### DIFF
--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -1,0 +1,64 @@
+defmodule Braintree.Plan do
+  @moduledoc """
+  Plans represent recurring billing plans in a Braintree merchant account.
+  The API for plans is read only.
+  """
+
+  use Braintree.Construction
+
+  alias Braintree.HTTP
+  alias Braintree.ErrorResponse, as: Error
+
+  @type t :: %__MODULE__{
+               id:                         String.t,
+               add_ons:                    [],
+               balance:                    String.t,
+               billing_day_of_month:       String.t,
+               billing_frequency:          String.t,
+               created_at:                 String.t,
+               currency_iso_code:          String.t,
+               description:                String.t,
+               discounts:                  [],
+               name:                       String.t,
+               number_of_billing_cycles:   String.t,
+               price:                      String.t,
+               trial_duration:             String.t,
+               trial_duration_unit:        String.t,
+               trial_period:               String.t,
+               updated_at:                 String.t
+             }
+
+  defstruct id:                         nil,
+            add_ons:                    [],
+            balance:                    nil,
+            billing_day_of_month:       nil,
+            billing_frequency:          nil,
+            created_at:                 nil,
+            currency_iso_code:          nil,
+            description:                nil,
+            discounts:                  [],
+            name:                       nil,
+            number_of_billing_cycles:   nil,
+            price:                      nil,
+            trial_duration:             nil,
+            trial_duration_unit:        nil,
+            trial_period:               nil,
+            updated_at:                 nil
+
+  @doc """
+  Get a list of all the plans defined in the merchant account. If there are
+  no plans an empty list is returned.
+
+  ## Example
+    {:ok, plans} = Braintree.Plans.all
+  """
+  @spec all() :: {:ok, t} | [{:error, Error.t}]
+  def all() do
+    case HTTP.request(:get, "plans") do
+      {:ok, response} ->
+        {:ok, Enum.map(response["plans"] || [], fn r -> construct(r) end)}
+      {:error, %{"api_error_response" => error}} ->
+        {:error, Error.construct(error)}
+    end
+  end
+end

--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -53,7 +53,7 @@ defmodule Braintree.Plan do
   no plans an empty list is returned.
 
   ## Example
-    {:ok, plans} = Braintree.Plans.all
+    {:ok, plans} = Braintree.Plan.all
   """
   @spec all() :: {:ok, t} | [{:error, Error.t}]
   def all do

--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -2,6 +2,9 @@ defmodule Braintree.Plan do
   @moduledoc """
   Plans represent recurring billing plans in a Braintree merchant account.
   The API for plans is read only.
+
+  For additional reference see:
+  https://developers.braintreepayments.com/reference/request/plan/all/ruby
   """
 
   use Braintree.Construction
@@ -53,10 +56,10 @@ defmodule Braintree.Plan do
     {:ok, plans} = Braintree.Plans.all
   """
   @spec all() :: {:ok, t} | [{:error, Error.t}]
-  def all() do
+  def all do
     case HTTP.request(:get, "plans") do
       {:ok, response} ->
-        {:ok, Enum.map(response["plans"] || [], fn r -> construct(r) end)}
+        {:ok, construct(Map.get(response, "plans", []))}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
     end

--- a/test/integration/plan_test.exs
+++ b/test/integration/plan_test.exs
@@ -1,0 +1,9 @@
+defmodule Braintree.Integration.PlanTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.Plan
+
+  test "all/0 can successfully get a response" do
+    {:ok, _} = Plan.all
+  end
+end

--- a/test/plan_test.exs
+++ b/test/plan_test.exs
@@ -1,0 +1,56 @@
+defmodule Braintree.PlanTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.Plan
+
+  test "construct/1 constructs a list of plans with nested maps available" do
+    [first_plan, second_plan] = Plan.construct([%{
+      "add_ons" => [],
+      "balance" => nil,
+      "billing_day_of_month" => nil,
+      "billing_frequency" => 1,
+      "created_at" => "2016-07-07T21:28:00Z",
+      "currency_iso_code" => "USD",
+      "description" => "Plan description",
+      "discounts" => [],
+      "id" => "1234",
+      "name" => "Plan name",
+      "number_of_billing_cycles" => nil,
+      "price" => "14.99",
+      "trial_duration" => nil,
+      "trial_duration_unit" => nil,
+      "trial_period" => false,
+      "updated_at" => "2016-07-07T21:28:00Z"
+    }, %{
+      "add_ons" => [%{
+        "amount" => "5.99",
+        "merchant_id" => "12345"
+      }],
+      "balance" => nil,
+      "billing_day_of_month" => nil,
+      "billing_frequency" => 1,
+      "created_at" => "2016-07-07T21:28:00Z",
+      "currency_iso_code" => "USD",
+      "description" => "Plan description",
+      "discounts" => [],
+      "id" => "5678",
+      "name" => "Plan name",
+      "number_of_billing_cycles" => nil,
+      "price" => "14.99",
+      "trial_duration" => nil,
+      "trial_duration_unit" => nil,
+      "trial_period" => false,
+      "updated_at" => "2016-07-07T21:28:00Z"
+    }])
+
+    assert second_plan.discounts == []
+
+    assert first_plan.add_ons == []
+    assert first_plan.discounts == []
+
+    [addon] = second_plan.add_ons
+
+    assert addon["amount"] == "5.99"
+    assert addon["merchant_id"] == "12345"
+  end
+end


### PR DESCRIPTION
Now that plans come through properly from the API here is support for `Plan.all`

I haven't added integration tests yet. As far as I can tell you're testing against your own sandbox? Either you could let me know what data you have in the sandbox for plans, or if you'd like to add some tests for this then that'd be welcome.

Hope this helps :)