### PR TITLE
Support {:system, VAR} for configs

### DIFF
--- a/lib/braintree.ex
+++ b/lib/braintree.ex
@@ -33,6 +33,13 @@ defmodule Braintree do
   """
   @spec get_env(atom, any) :: any
   def get_env(key, default \\ nil) do
-    Application.get_env(:braintree, key, default) || raise ConfigError, key
+    case Application.fetch_env(:braintree, key) do
+      {:ok, {:system, var}} when is_binary(var) ->
+        System.get_env(var) || raise ConfigError, key
+      {:ok, value} ->
+        value
+      :error ->
+        raise ConfigError, key
+    end
   end
 end

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -13,7 +13,9 @@ defmodule Braintree.HTTP do
   * public_key - Braintree public key
 
   All three must have values set or a `Braintree.ConfigError` will be raised
-  at runtime.
+  at runtime. All those config values support the `{:system, "VAR_NAME"}`
+  as a value - in that case the value will be read from the system environment
+  with `System.get_env("VAR_NAME")`.
   """
 
   require Logger

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -6,7 +6,7 @@ defmodule Braintree.HTTPTest do
   alias Braintree.{ConfigError, HTTP}
 
   test "process_url/1 prepends the endpoint" do
-    merchant_id = Application.get_env(:braintree, :merchant_id)
+    merchant_id = Braintree.get_env(:merchant_id)
 
     assert HTTP.process_url("customer") =~
       "sandbox.braintreegateway.com/merchants/#{merchant_id}/customer"
@@ -70,7 +70,7 @@ defmodule Braintree.HTTPTest do
     value = Application.get_env(:braintree, key)
 
     try do
-      Application.put_env(:braintree, key, nil)
+      Application.delete_env(:braintree, key)
       assert_raise ConfigError, "missing config for :#{key}", fun
     after
       Application.put_env(:braintree, key, value)


### PR DESCRIPTION
It's a pretty common patten for configuring API keys, and makes using the library in releases much easier.