### PR TITLE
This patch correctly handles &amp; in the Braintree response XML

### DIFF
--- a/lib/xml/decoder.ex
+++ b/lib/xml/decoder.ex
@@ -19,6 +19,12 @@ defmodule Braintree.XML.Decoder do
 
       iex> Braintree.XML.Decoder.load("<a><b type='string'>Jos&#233;</b></a>")
       %{"a" => %{"b" => "José"}}
+
+      iex> Braintree.XML.Decoder.load("<a><b type='string'>First &amp; Last</b></a>")
+      %{"a" => %{"b" => "First & Last"}}
+
+      iex> Braintree.XML.Decoder.load("<a><b type='string'>&quot;air quotes&quot;</b></a>")
+      %{"a" => %{"b" => ~s("air quotes")}}
   """
   @spec load(xml) :: Map.t
   def load(""), do: %{}
@@ -56,8 +62,13 @@ defmodule Braintree.XML.Decoder do
     |> List.first
   end
 
-  defp transform(elements) when is_list(elements),
-    do: Enum.into(without_nil(elements), %{}, &transform/1)
+  defp transform(elements) when is_list(elements) do
+    if is_text_list?(elements) do
+      Enum.join(elements, " ")
+    else
+      Enum.into(without_nil(elements), %{}, &transform/1)
+    end
+  end
 
   defp transform({[type: "array"], elements}),
     do: Enum.map(without_nil(elements), &(elem(transform(&1), 1)))
@@ -82,6 +93,10 @@ defmodule Braintree.XML.Decoder do
 
   defp transform({name, _, values}),
     do: {name, transform(values)}
+
+  defp is_text_list?([last]) when is_binary(last), do: true
+  defp is_text_list?([hd|rest]) when is_binary(hd), do: is_text_list?(rest)
+  defp is_text_list?(_), do: false
 
   defp without_nil(list),
     do: Enum.reject(list, &Kernel.==(&1, nil))

--- a/lib/xml/entity.ex
+++ b/lib/xml/entity.ex
@@ -2,18 +2,24 @@ defmodule Braintree.XML.Entity do
   @external_resource entities = Path.join([__DIR__, "../../priv/entities.txt"])
 
   @doc """
-  Replace any escaped HTML entities with the unicode value.
+  Replace all escaped HTML entities, except those that would produce invalid XML
 
   ## Examples
 
       iex> Braintree.XML.Entity.decode("&lt;tag&gt;")
-      "<tag>"
+      "&lt;tag&gt;"
 
       iex> Braintree.XML.Entity.decode("S&#248;ren")
       "Søren"
 
       iex> Braintree.XML.Entity.decode("Normal")
       "Normal"
+
+      iex> Braintree.XML.Entity.decode("First &amp; Last")
+      "First &amp; Last"
+
+      iex> Braintree.XML.Entity.decode("&quot;air quotes&quot;")
+      ~s("air quotes")
   """
   def decode(string) do
     Regex.replace(~r/\&([^\s]+);/U, string, &replace/2)

--- a/priv/entities.txt
+++ b/priv/entities.txt
@@ -1,8 +1,5 @@
 quot,",34
-amp,&,38
 apos,',39
-lt,<,60
-gt,>,62
 nbsp, ,160
 iexcl,¡,161
 cent,¢,162


### PR DESCRIPTION
I removed entities that should not be decoded before xmerl parses the document, as doing so, would produce invalid XML.

This should solve for #23
