### PR TITLE
Fix typo in in typespec

### DIFF
--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -41,7 +41,7 @@ defmodule Braintree.Transaction do
                order_id:                           String.t,
                payment_instrument_type:            String.t,
                paypal:                             Map.t,
-               plan_id:                            Sting.t,
+               plan_id:                            String.t,
                processor_authorization_code:       String.t,
                processor_response_code:            String.t,
                processor_response_text:            String.t,


### PR DESCRIPTION
# Why?
Because Sting != String...and it was blowing up dialyxer.

# What changed?
Fixed the typo.