### PR TITLE
Allow strings from environment to be used for "environment" config key

### DIFF
--- a/lib/braintree.ex
+++ b/lib/braintree.ex
@@ -63,6 +63,7 @@ defmodule Braintree do
       :error ->
         fallback_or_raise(key, nil, default)
     end
+    |> format(key)
   end
 
   @doc """
@@ -83,4 +84,7 @@ defmodule Braintree do
   defp fallback_or_raise(key, nil, nil),   do: raise ConfigError, key
   defp fallback_or_raise(_, nil, default), do: default
   defp fallback_or_raise(_, value, _),     do: value
+
+  defp format(value, :environment) when is_binary(value), do: String.to_existing_atom(value)
+  defp format(value, _key),                               do: value
 end


### PR DESCRIPTION
You allow setting of braintree environment using the system tuple pattern:

```elixir
config :braintree,
  environment: {:system, "BRAINTREE_ENVIRONMENT"},
  merchant_id: {:system, "BRAINTREE_MERCHANT_ID"},
  public_key:  {:system, "BRAINTREE_PUBLIC_KEY"},
  private_key: {:system, "BRAINTREE_PRIVATE_KEY"}
```

But the environment has to be an `Atom`...

This PR allows you to set it as a `String` and it will still work.