### PR TITLE
Add dialyxir and fix all the typespecs

### DIFF
--- a/lib/add_on.ex
+++ b/lib/add_on.ex
@@ -13,6 +13,7 @@ defmodule Braintree.AddOn do
   use Braintree.Construction
 
   alias Braintree.HTTP
+  alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
                id:                       String.t,

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -59,7 +59,7 @@ defmodule Braintree.Address do
 
     address.company # Braintree
   """
-  @spec create(binary, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec create(binary, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def create(customer_id, params \\ %{}, opts \\ []) when is_binary(customer_id) do
     with {:ok, payload} <- HTTP.post("customers/#{customer_id}/addresses/", %{address: params}, opts) do
       {:ok, new(payload)}
@@ -81,8 +81,8 @@ defmodule Braintree.Address do
   end
 
   @doc """
-  To update an address, use a customer's ID with an address's ID along with 
-  new attributes. The same validations apply as when creating an address. 
+  To update an address, use a customer's ID with an address's ID along with
+  new attributes. The same validations apply as when creating an address.
   Any attribute not passed will remain unchanged.
 
   ## Example
@@ -93,7 +93,7 @@ defmodule Braintree.Address do
 
       address.company # "New Company Name"
   """
-  @spec update(binary, binary, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec update(binary, binary, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def update(customer_id, id, params, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <- HTTP.put("customers/#{customer_id}/addresses/" <> id, %{address: params}, opts) do
       {:ok, new(payload)}
@@ -122,6 +122,5 @@ defmodule Braintree.Address do
 
       address = Braintree.Address.new(%{"company" => "Braintree"})
   """
-  @spec new(Map.t) :: t
   def new(%{"address" => map}), do: super(map)
 end

--- a/lib/braintree.ex
+++ b/lib/braintree.ex
@@ -13,14 +13,12 @@ defmodule Braintree do
     Raised at runtime when a config variable is missing.
     """
 
-    @type t :: %__MODULE__{message: String.t}
-
     defexception [:message]
 
     @doc """
     Build a new ConfigError exception.
     """
-    @spec exception(String.t) :: t
+    @impl true
     def exception(value) do
       message = "missing config for :#{value}"
 

--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -7,6 +7,7 @@ defmodule Braintree.ClientToken do
   """
 
   alias Braintree.HTTP
+  alias Braintree.ErrorResponse, as: Error
 
   @version 2
 
@@ -27,7 +28,7 @@ defmodule Braintree.ClientToken do
 
       {:ok, token} = Braintree.ClientToken.generate(%{version: 3})
   """
-  @spec generate(Map.t, Keyword.t) :: {:ok, binary} | {:error, Error.t}
+  @spec generate(map, Keyword.t) :: {:ok, binary} | {:error, Error.t}
   def generate(params \\ %{}, opts \\ []) when is_map(params) do
     params = %{client_token: with_version(params)}
 

--- a/lib/construction.ex
+++ b/lib/construction.ex
@@ -11,7 +11,7 @@ defmodule Braintree.Construction do
       @doc """
       Convert a response into one or more typed structs.
       """
-      @spec new(Map.t | [Map.t]) :: t | [t]
+      @spec new(map | [map]) :: t | [t]
       def new(params) when is_map(params) do
         struct(__MODULE__, atomize(params))
       end

--- a/lib/credit_card.ex
+++ b/lib/credit_card.ex
@@ -31,8 +31,8 @@ defmodule Braintree.CreditCard do
                created_at:               String.t,
                updated_at:               String.t,
                venmo_sdk:                boolean,
-               subscriptions:            [],
-               verifications:            []
+               subscriptions:            [any],
+               verifications:            [any]
              }
 
   defstruct bin:                      nil,

--- a/lib/credit_card_verification.ex
+++ b/lib/credit_card_verification.ex
@@ -12,7 +12,7 @@ defmodule Braintree.CreditCardVerification do
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
-                amount:                             Decimal.t,
+                amount:                             String.t,
                 avs_error_response_code:            String.t,
                 avs_postal_code_response_code:      String.t,
                 avs_street_address_response_code:   String.t,
@@ -26,7 +26,7 @@ defmodule Braintree.CreditCardVerification do
                 merchant_account_id:                String.t,
                 processor_response_code:            String.t,
                 processor_response_text:            String.t,
-                risk_data:                          %{},
+                risk_data:                          map,
                 status:                             String.t
             }
 
@@ -57,7 +57,7 @@ defmodule Braintree.CreditCardVerification do
 
     {:ok, verifications} = Braintree.CreditCardVerification.search(search_params)
   """
-  @spec search(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec search(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def search(params, opts \\ []) when is_map(params) do
     Search.perform(params, "verifications", &new/1, opts)
   end
@@ -69,7 +69,6 @@ defmodule Braintree.CreditCardVerification do
 
       verification = Braintree.CreditCardVerification.new(%{"credit_card_card_type" => "Visa"})
   """
-  @spec new(Map.t | [Map.t]) :: t | [t]
   def new(%{"credit_card_verification" => map}) do
     new(map)
   end

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -23,11 +23,11 @@ defmodule Braintree.Customer do
                website:           String.t,
                created_at:        String.t,
                updated_at:        String.t,
-               custom_fields:     %{},
-               addresses:         [],
-               credit_cards:      [],
-               paypal_accounts:   [],
-               coinbase_accounts: []
+               custom_fields:     map,
+               addresses:         [map],
+               credit_cards:      [CreditCard.t],
+               paypal_accounts:   [PaypalAccount.t],
+               coinbase_accounts: [map]
              }
 
   defstruct id:                nil,
@@ -64,7 +64,7 @@ defmodule Braintree.Customer do
 
       customer.company # Braintree
   """
-  @spec create(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("customers", %{customer: params}, opts) do
       {:ok, new(payload)}
@@ -114,7 +114,7 @@ defmodule Braintree.Customer do
 
       customer.company # "New Company Name"
   """
-  @spec update(binary, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec update(binary, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("customers/" <> id, %{customer: params}, opts) do
       {:ok, new(payload)}
@@ -129,7 +129,7 @@ defmodule Braintree.Customer do
 
     {:ok, customers} = Braintree.Customer.search(%{first_name: %{is: "Jenna"}})
   """
-  @spec search(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec search(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def search(params, opts \\ []) when is_map(params) do
     Search.perform(params, "customers", &new/1, opts)
   end
@@ -143,7 +143,6 @@ defmodule Braintree.Customer do
       customer = Braintree.Customer.new(%{"company" => "Soren",
                                           "email" => "parker@example.com"})
   """
-  @spec new(Map.t | [Map.t]) :: t | [t]
   def new(%{"customer" => map}) do
     new(map)
   end

--- a/lib/error_response.ex
+++ b/lib/error_response.ex
@@ -13,10 +13,10 @@ defmodule Braintree.ErrorResponse do
   use Braintree.Construction
 
   @type t :: %__MODULE__{
-               errors: Map.t,
+               errors: map,
                message: String.t,
-               params: Map.t,
-               transaction: Map.t
+               params: map,
+               transaction: map
              }
 
   defstruct errors: %{},

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -24,8 +24,8 @@ defmodule Braintree.HTTP do
   alias Braintree.ErrorResponse, as: Error
 
   @type response ::
-          {:ok, Map.t() | {:error, atom}}
-          | {:error, Error.t()}
+          {:ok, map | {:error, atom}}
+          | {:error, Error.t}
           | {:error, binary}
 
   @endpoints [
@@ -70,7 +70,7 @@ defmodule Braintree.HTTP do
         end
       end
   """
-  @spec request(atom, binary, binary | Map.t(), Keyword.t()) :: response
+  @spec request(atom, binary, binary | map, Keyword.t) :: response
   def request(method, path, body \\ %{}, opts \\ []) do
     response =
       :hackney.request(
@@ -125,7 +125,7 @@ defmodule Braintree.HTTP do
   ## Helper Functions
 
   @doc false
-  @spec build_url(binary, Keyword.t()) :: binary
+  @spec build_url(binary, Keyword.t) :: binary
   def build_url(path, opts) do
     environment = opts |> get_lazy_env(:environment) |> maybe_to_atom()
     merchant_id = get_lazy_env(opts, :merchant_id)
@@ -141,12 +141,12 @@ defmodule Braintree.HTTP do
   defp maybe_to_atom(value) when is_atom(value), do: value
 
   @doc false
-  @spec encode_body(binary | Map.t()) :: binary
+  @spec encode_body(binary | map) :: binary
   def encode_body(body) when body == "" or body == %{}, do: ""
   def encode_body(body), do: Encoder.dump(body)
 
   @doc false
-  @spec decode_body(binary) :: Map.t()
+  @spec decode_body(binary) :: map
   def decode_body(body) do
     body
     |> :zlib.gunzip()
@@ -163,7 +163,7 @@ defmodule Braintree.HTTP do
   end
 
   @doc false
-  @spec build_headers(Keyword.t()) :: [tuple]
+  @spec build_headers(Keyword.t) :: [tuple]
   def build_headers(opts) do
     public = Keyword.get_lazy(opts, :public_key, fn -> Braintree.get_env(:public_key) end)
     private = Keyword.get_lazy(opts, :private_key, fn -> Braintree.get_env(:private_key) end)
@@ -181,7 +181,7 @@ defmodule Braintree.HTTP do
   end
 
   @doc false
-  @spec code_to_reason(integer | atom) :: integer
+  @spec code_to_reason(integer) :: atom
   def code_to_reason(integer)
 
   for {code, status} <- @statuses do

--- a/lib/merchant/account.ex
+++ b/lib/merchant/account.ex
@@ -41,7 +41,7 @@ defmodule Braintree.Merchant.Account do
       tos_accepted: true,
     })
   """
-  @spec create(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("merchant_accounts/create_via_api", %{merchant_account: params}, opts) do
       {:ok, new(payload)}
@@ -61,7 +61,7 @@ defmodule Braintree.Merchant.Account do
 
       merchant.funding_details.account_number # "1234567890"
   """
-  @spec update(binary, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec update(binary, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def update(id, params, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.put("merchant_accounts/#{id}/update_via_api", %{merchant_account: params}, opts) do
       {:ok, new(payload)}
@@ -85,6 +85,5 @@ defmodule Braintree.Merchant.Account do
   @doc """
   Convert a map into a `Braintree.Merchant.Account` struct.
   """
-  @spec new(Map.t) :: t
   def new(%{"merchant_account" => map}), do: super(map)
 end

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -25,7 +25,7 @@ defmodule Braintree.PaymentMethod do
 
       credit_card.type # "Visa"
   """
-  @spec create(Map.t, Keyword.t) :: {:ok, CreditCard.t} | {:ok, PaypalAccount.t} | {:error, Error.t}
+  @spec create(map, Keyword.t) :: {:ok, CreditCard.t} | {:ok, PaypalAccount.t} | {:error, Error.t}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("payment_methods", %{payment_method: params}, opts) do
       {:ok, new(payload)}
@@ -56,7 +56,7 @@ defmodule Braintree.PaymentMethod do
 
       payment_method.cardholder_name # "NEW"
   """
-  @spec update(String.t, Map.t, Keyword.t) :: {:ok, CreditCard.t} | {:ok, PaypalAccount.t} | {:error, Error.t}
+  @spec update(String.t, map, Keyword.t) :: {:ok, CreditCard.t} | {:ok, PaypalAccount.t} | {:error, Error.t}
   def update(token, params \\ %{}, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -99,7 +99,7 @@ defmodule Braintree.PaymentMethod do
     end
   end
 
-  @spec new(Map.t) :: CreditCard.t | PaypalAccount.t
+  @spec new(map) :: CreditCard.t | PaypalAccount.t
   defp new(%{"credit_card" => credit_card}) do
     CreditCard.new(credit_card)
   end

--- a/lib/payment_method_nonce.ex
+++ b/lib/payment_method_nonce.ex
@@ -14,10 +14,10 @@ defmodule Braintree.PaymentMethodNonce do
                nonce:               String.t,
                three_d_secure_info: String.t,
                type:                String.t,
-               details:             Map.t,
+               details:             map,
                is_locked:           boolean,
                consumed:            boolean,
-               security_questions:  []
+               security_questions:  [any]
              }
 
   defstruct default:              nil,
@@ -67,7 +67,6 @@ defmodule Braintree.PaymentMethodNonce do
   end
 
   @doc false
-  @spec new(Map.t) :: t
   def new(%{"payment_method_nonce" => map}) do
     super(map)
   end

--- a/lib/paypal_account.ex
+++ b/lib/paypal_account.ex
@@ -19,7 +19,7 @@ defmodule Braintree.PaypalAccount do
                updated_at:           String.t,
                default:              boolean,
                is_channel_initated:  boolean,
-               subscriptions:        []
+               subscriptions:        [any]
              }
 
   defstruct billing_agreement_id: nil,
@@ -61,7 +61,7 @@ defmodule Braintree.PaypalAccount do
         %{options: %{make_default: true}
       )
   """
-  @spec update(String.t, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec update(String.t, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def update(token, params, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 

--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -14,14 +14,14 @@ defmodule Braintree.Plan do
 
   @type t :: %__MODULE__{
                id:                       String.t,
-               add_ons:                  [],
+               add_ons:                  [any],
                balance:                  String.t,
                billing_day_of_month:     String.t,
                billing_frequency:        String.t,
                created_at:               String.t,
                currency_iso_code:        String.t,
                description:              String.t,
-               discounts:                [],
+               discounts:                [any],
                name:                     String.t,
                number_of_billing_cycles: String.t,
                price:                    String.t,

--- a/lib/search.ex
+++ b/lib/search.ex
@@ -7,7 +7,7 @@ defmodule Braintree.Search do
   """
 
   alias Braintree.HTTP
-  alias Braintree.Error, as: Error
+  alias Braintree.ErrorResponse, as: Error
 
   @doc """
   Perform an advanced search on a given resource and create new structs
@@ -18,7 +18,7 @@ defmodule Braintree.Search do
     {:ok, customers} = Braintree.Search.perform(search_params, "customers", &Braintree.Customer.new/1)
 
   """
-  @spec perform(Map.t, String.t, fun(), Keyword.t) :: {:ok, List.t} | {:error, Error.t}
+  @spec perform(map, String.t, fun(), Keyword.t) :: {:ok, [any]} | {:error, Error.t}
   def perform(params, resource, initializer, opts \\ []) when is_map(params) do
     with {:ok, payload} <- HTTP.post(resource <> "/advanced_search_ids", %{search: params}, opts) do
       fetch_all_records(payload, resource, initializer, opts)

--- a/lib/settlement_batch_summary.ex
+++ b/lib/settlement_batch_summary.ex
@@ -35,7 +35,7 @@ defmodule Braintree.SettlementBatchSummary do
     Convert a list of records into structs, including any custom fields that
     were used as the grouping value.
     """
-    @spec new(Map.t | [Map.t]) :: t | [t]
+    @spec new(map | [map]) :: t | [t]
     def new(params) when is_map(params) do
       atomized = atomize(params)
       summary = struct(__MODULE__, atomized)
@@ -75,7 +75,7 @@ defmodule Braintree.SettlementBatchSummary do
     end
   end
 
-  @spec build_criteria(binary, binary | nil) :: Map.t
+  @spec build_criteria(binary, binary | nil) :: map
   defp build_criteria(settlement_date, nil) do
     %{settlement_date: settlement_date}
   end
@@ -87,7 +87,6 @@ defmodule Braintree.SettlementBatchSummary do
   Convert a map including records into a summary struct with a list
   of record structs.
   """
-  @spec new(Map.t) :: t
   def new(%{"records" => records}) do
     struct(__MODULE__, records: Record.new(records))
   end

--- a/lib/subscription.ex
+++ b/lib/subscription.ex
@@ -38,10 +38,10 @@ defmodule Braintree.Subscription do
                trial_duration_unit:        String.t,
                trial_period:               String.t,
                updated_at:                 String.t,
-               add_ons:                    [],
-               discounts:                  [],
-               transactions:               [],
-               status_history:             []
+               add_ons:                    [AddOn.t],
+               discounts:                  [any],
+               transactions:               [Transaction.t],
+               status_history:             [any]
              }
 
   defstruct id:                         nil,
@@ -86,7 +86,7 @@ defmodule Braintree.Subscription do
         plan_id: "starter"
       })
   """
-  @spec create(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec create(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("subscriptions", %{subscription: params}, opts) do
       {:ok, new(payload)}
@@ -156,7 +156,7 @@ defmodule Braintree.Subscription do
       })
       subscription.plan_id # "new_plan_id"
   """
-  @spec update(binary, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec update(binary, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("subscriptions/" <> id, %{subscription: params}, opts) do
       {:ok, new(payload)}
@@ -170,7 +170,7 @@ defmodule Braintree.Subscription do
 
     {:ok, subscriptions} = Braintree.Subscription.search(%{plan_id: %{is: "starter"}})
   """
-  @spec search(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec search(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def search(params, opts \\ []) when is_map(params) do
     Search.perform(params, "subscriptions", &new/1, opts)
   end
@@ -184,7 +184,6 @@ defmodule Braintree.Subscription do
       subscripton = Braintree.Subscription.new(%{"plan_id" => "business",
                                                  "status" => "Active"})
   """
-  @spec new(Map.t | [Map.t]) :: t | [t]
   def new(%{"subscription" => map}) do
     new(map)
   end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -14,33 +14,33 @@ defmodule Braintree.Transaction do
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
-               add_ons:                            [],
+               add_ons:                            [AddOn.t],
                additional_processor_response:      String.t,
                amount:                             number,
                apple_pay_details:                  String.t,
                avs_error_response_code:            String.t,
                avs_postal_code_response_code:      String.t,
                avs_street_address_response_code:   String.t,
-               billing:                            Map.t,
+               billing:                            map,
                channel:                            String.t,
                coinbase_details:                   String.t,
                created_at:                         String.t,
-               credit_card_details:                Map.t,
+               credit_card_details:                map,
                currency_iso_code:                  String.t,
-               custom_fields:                      Map.t,
-               customer_details:                   Map.t,
+               custom_fields:                      map,
+               customer_details:                   map,
                cvv_response_code:                  String.t,
-               descriptor:                         Map.t,
-               disbursement_details:               Map.t,
-               discounts:                          [],
-               disputes:                           [],
+               descriptor:                         map,
+               disbursement_details:               map,
+               discounts:                          [any],
+               disputes:                           [any],
                escrow_status:                      String.t,
                gateway_rejection_reason:           String.t,
                id:                                 String.t,
                merchant_account_id:                String.t,
                order_id:                           String.t,
                payment_instrument_type:            String.t,
-               paypal:                             Map.t,
+               paypal:                             map,
                plan_id:                            String.t,
                processor_authorization_code:       String.t,
                processor_response_code:            String.t,
@@ -54,10 +54,10 @@ defmodule Braintree.Transaction do
                risk_data:                          String.t,
                service_fee_amount:                 number,
                settlement_batch_id:                String.t,
-               shipping_details:                   Map.t,
+               shipping_details:                   map,
                status:                             String.t,
                status_history:                     String.t,
-               subscription_details:               Map.t,
+               subscription_details:               map,
                subscription_id:                    String.t,
                tax_amount:                         number,
                tax_exempt:                         boolean,
@@ -131,7 +131,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "settling"
   """
-  @spec sale(Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec sale(map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def sale(params, opts \\ []) do
     sale_params = Map.merge(params, %{type: "sale"})
 
@@ -149,7 +149,7 @@ defmodule Braintree.Transaction do
       {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
       transaction.status # "settling"
   """
-  @spec submit_for_settlement(String.t, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec submit_for_settlement(String.t, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def submit_for_settlement(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/submit_for_settlement"
 
@@ -168,7 +168,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "refunded"
   """
-  @spec refund(String.t, Map.t, Keyword.t) :: {:ok, t} | {:error, Error.t}
+  @spec refund(String.t, map, Keyword.t) :: {:ok, t} | {:error, Error.t}
   def refund(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/refund"
 
@@ -221,7 +221,6 @@ defmodule Braintree.Transaction do
       transaction = Braintree.Transaction.new(%{"subscription_id" => "subxid",
                                                       "status" => "submitted_for_settlement"})
   """
-  @spec new(Map.t | [Map.t]) :: t | [t]
   def new(%{"transaction" => map}) do
     new(map)
   end

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -52,7 +52,7 @@ defmodule Braintree.Util do
       iex> Braintree.Util.atomize(%{"a" => 1, "b" => %{"c" => 2}})
       %{a: 1, b: %{c: 2}}
   """
-  @spec atomize(Map.t) :: Map.t
+  @spec atomize(map) :: map
   def atomize(map) when is_map(map) do
     Enum.into(map, %{}, fn
       {key, val} when is_map(val) -> {String.to_atom(key), atomize(val)}

--- a/lib/xml/decoder.ex
+++ b/lib/xml/decoder.ex
@@ -26,7 +26,7 @@ defmodule Braintree.XML.Decoder do
       iex> Braintree.XML.Decoder.load("<a><b type='string'>&quot;air quotes&quot;</b></a>")
       %{"a" => %{"b" => ~s("air quotes")}}
   """
-  @spec load(xml) :: Map.t
+  @spec load(xml) :: map
   def load(""), do: %{}
 
   def load(xml) do

--- a/lib/xml/encoder.ex
+++ b/lib/xml/encoder.ex
@@ -21,7 +21,7 @@ defmodule Braintree.XML.Encoder do
       iex> Braintree.XML.Encoder.dump(%{a: %{b: "<tag>"}})
       ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<a>\n<b>&lt;tag&gt;</b>\n</a>|
   """
-  @spec dump(Map.t) :: xml
+  @spec dump(map) :: xml
   def dump(map) do
     generated =
       map

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Braintree.Mixfile do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.9.0"
 
   def project do
     [
@@ -16,7 +16,11 @@ defmodule Braintree.Mixfile do
       package: package(),
       name: "Braintree",
       deps: deps(),
-      docs: docs()
+      docs: docs(),
+      dialyzer: [
+        plt_add_deps: :transitive,
+        flags: [:unmatched_returns, :error_handling]
+      ]
     ]
   end
 
@@ -55,7 +59,8 @@ defmodule Braintree.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:inch_ex, ">= 0.0.0", only: :dev},
-      {:excoveralls, "~> 0.7", only: [:dev, :test]}
+      {:excoveralls, "~> 0.7", only: [:dev, :test]},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.7.2", "f69ede8c122ccd3b60afc775348a53fc8c39fe4278aee2f538f0d81cc5e7ff3a", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
I was trying to use dialyzer in a project of mine using this library and noticed errors that I couldn't fix without touching this library.  Here are some fixes I think will help, but there's plenty of room for other improvements.  At least I think this is a good start.

The main issues:
* `Map.t` doesn't exist, it should just be `map`
* `[]` I think matches only "empty list". `[any]` is a generic "list of zero or more anything"
* The exception stuff was a bit squirrelly, I opted to just treat it like a behavior implementation
* Because `new/1` was being defined in `Braintree.Construction`, I removed the typespecs for all the overridden ones, because dialyzer can't handle more than one typespec per function

Hope this helps, let me know if you'd like anything changed! ;)