### PR TITLE
Feature - Add TransactionLineItem.find_all/1

### DIFF
--- a/lib/transaction_line_item.ex
+++ b/lib/transaction_line_item.ex
@@ -1,0 +1,74 @@
+defmodule Braintree.TransactionLineItem do
+  @moduledoc """
+  For fetching line items for a given transaction.
+
+  https://developers.braintreepayments.com/reference/response/transaction-line-item/ruby
+  """
+
+  use Braintree.Construction
+
+  alias Braintree.{HTTP}
+  alias Braintree.ErrorResponse, as: Error
+
+  @type t :: %__MODULE__{
+          commodity_code: String.t(),
+          description: String.t(),
+          discount_amount: String.t(),
+          kind: String.t(),
+          name: String.t(),
+          product_code: String.t(),
+          quantity: String.t(),
+          tax_amount: String.t(),
+          total_amount: String.t(),
+          unit_amount: String.t(),
+          unit_of_measure: String.t(),
+          unit_tax_amount: String.t(),
+          url: String.t()
+        }
+
+  defstruct commodity_code: nil,
+            description: nil,
+            discount_amount: nil,
+            kind: nil,
+            name: nil,
+            product_code: nil,
+            quantity: nil,
+            tax_amount: nil,
+            total_amount: nil,
+            unit_amount: nil,
+            unit_of_measure: nil,
+            unit_tax_amount: nil,
+            url: nil
+
+  @doc """
+  Find transaction line items for the given transaction id.
+
+  ## Example
+
+      {:ok, transaction_line_items} = TransactionLineItem.find("123")
+  """
+  @spec find_all(String.t(), Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  def find_all(transaction_id, opts \\ []) do
+    path = "transactions/#{transaction_id}/line_items"
+
+    with {:ok, payload} <- HTTP.get(path, opts) do
+      {:ok, new(payload)}
+    end
+  end
+
+  @doc """
+  Converts a list of transaction line item maps into a list of transaction line items.
+
+  ## Example
+
+  transaction_line_items =
+    Braintree.TransactionLineItem.new(%{
+      "name" => "item name",
+      "total_amount" => "100.00"
+  })
+  """
+  @spec new(%{required(line_items :: String.t()) => [map]}) :: [t]
+  def new(%{"line_items" => line_item_maps}) do
+    Enum.map(line_item_maps, &super/1)
+  end
+end

--- a/lib/transaction_line_item.ex
+++ b/lib/transaction_line_item.ex
@@ -7,7 +7,7 @@ defmodule Braintree.TransactionLineItem do
 
   use Braintree.Construction
 
-  alias Braintree.{HTTP}
+  alias Braintree.HTTP
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{

--- a/test/integration/transaction_line_item_test.exs
+++ b/test/integration/transaction_line_item_test.exs
@@ -23,7 +23,6 @@ defmodule Braintree.Integration.TransactionLineItemTest do
           commodity_code: "98765",
           url: "https://product.com"
         },
-
         %{
           name: "Other Product Name",
           description: "Other product that is still super profitable",
@@ -38,7 +37,7 @@ defmodule Braintree.Integration.TransactionLineItemTest do
           product_code: "54322",
           commodity_code: "98766",
           url: "https://otherproduct.com"
-        },
+        }
       ]
 
     {:ok, transaction} =
@@ -51,32 +50,11 @@ defmodule Braintree.Integration.TransactionLineItemTest do
     {:ok, [transaction_line_item, other_transaction_line_item]} =
       TransactionLineItem.find_all(transaction.id)
 
-    assert transaction_line_item.name == line_item.name
-    assert transaction_line_item.description == line_item.description
-    assert transaction_line_item.kind == line_item.kind
-    assert transaction_line_item.quantity == line_item.quantity
-    assert transaction_line_item.unit_amount == line_item.unit_amount
-    assert transaction_line_item.unit_of_measure == line_item.unit_of_measure
-    assert transaction_line_item.total_amount == line_item.total_amount
-    assert transaction_line_item.tax_amount == line_item.tax_amount
-    assert transaction_line_item.unit_tax_amount == line_item.unit_tax_amount
-    assert transaction_line_item.discount_amount == line_item.discount_amount
-    assert transaction_line_item.product_code == line_item.product_code
-    assert transaction_line_item.commodity_code == line_item.commodity_code
-    assert transaction_line_item.url == line_item.url
+    line_item_keys = Map.keys(line_item)
 
-    assert other_transaction_line_item.name == other_line_item.name
-    assert other_transaction_line_item.description == other_line_item.description
-    assert other_transaction_line_item.kind == other_line_item.kind
-    assert other_transaction_line_item.quantity == other_line_item.quantity
-    assert other_transaction_line_item.unit_amount == other_line_item.unit_amount
-    assert other_transaction_line_item.unit_of_measure == other_line_item.unit_of_measure
-    assert other_transaction_line_item.total_amount == other_line_item.total_amount
-    assert other_transaction_line_item.tax_amount == other_line_item.tax_amount
-    assert other_transaction_line_item.unit_tax_amount == other_line_item.unit_tax_amount
-    assert other_transaction_line_item.discount_amount == other_line_item.discount_amount
-    assert other_transaction_line_item.product_code == other_line_item.product_code
-    assert other_transaction_line_item.commodity_code == other_line_item.commodity_code
-    assert other_transaction_line_item.url == other_line_item.url
+    assert Map.take(transaction_line_item, line_item_keys) == Map.take(line_item, line_item_keys)
+
+    assert Map.take(other_transaction_line_item, line_item_keys) ==
+             Map.take(other_line_item, line_item_keys)
   end
 end

--- a/test/integration/transaction_line_item_test.exs
+++ b/test/integration/transaction_line_item_test.exs
@@ -1,0 +1,82 @@
+defmodule Braintree.Integration.TransactionLineItemTest do
+  use ExUnit.Case, async: true
+
+  alias Braintree.{Transaction, TransactionLineItem}
+  alias Braintree.Testing.Nonces
+
+  @moduletag :integration
+  test "find/1 returns a list of transaction line items" do
+    [line_item, other_line_item] =
+      line_items = [
+        %{
+          name: "Product Name",
+          description: "Super profitable product",
+          kind: "debit",
+          quantity: "10",
+          unit_amount: "9.5",
+          unit_of_measure: "unit",
+          total_amount: "95.00",
+          tax_amount: "5.00",
+          unit_tax_amount: "0.50",
+          discount_amount: "1.00",
+          product_code: "54321",
+          commodity_code: "98765",
+          url: "https://product.com"
+        },
+
+        %{
+          name: "Other Product Name",
+          description: "Other product that is still super profitable",
+          kind: "debit",
+          quantity: "10",
+          unit_amount: "8.5",
+          unit_of_measure: "unit",
+          total_amount: "85.00",
+          tax_amount: "4.00",
+          unit_tax_amount: "0.40",
+          discount_amount: "2.00",
+          product_code: "54322",
+          commodity_code: "98766",
+          url: "https://otherproduct.com"
+        },
+      ]
+
+    {:ok, transaction} =
+      Transaction.sale(%{
+        amount: "100.00",
+        payment_method_nonce: Nonces.transactable(),
+        line_items: line_items
+      })
+
+    {:ok, [transaction_line_item, other_transaction_line_item]} =
+      TransactionLineItem.find_all(transaction.id)
+
+    assert transaction_line_item.name == line_item.name
+    assert transaction_line_item.description == line_item.description
+    assert transaction_line_item.kind == line_item.kind
+    assert transaction_line_item.quantity == line_item.quantity
+    assert transaction_line_item.unit_amount == line_item.unit_amount
+    assert transaction_line_item.unit_of_measure == line_item.unit_of_measure
+    assert transaction_line_item.total_amount == line_item.total_amount
+    assert transaction_line_item.tax_amount == line_item.tax_amount
+    assert transaction_line_item.unit_tax_amount == line_item.unit_tax_amount
+    assert transaction_line_item.discount_amount == line_item.discount_amount
+    assert transaction_line_item.product_code == line_item.product_code
+    assert transaction_line_item.commodity_code == line_item.commodity_code
+    assert transaction_line_item.url == line_item.url
+
+    assert other_transaction_line_item.name == other_line_item.name
+    assert other_transaction_line_item.description == other_line_item.description
+    assert other_transaction_line_item.kind == other_line_item.kind
+    assert other_transaction_line_item.quantity == other_line_item.quantity
+    assert other_transaction_line_item.unit_amount == other_line_item.unit_amount
+    assert other_transaction_line_item.unit_of_measure == other_line_item.unit_of_measure
+    assert other_transaction_line_item.total_amount == other_line_item.total_amount
+    assert other_transaction_line_item.tax_amount == other_line_item.tax_amount
+    assert other_transaction_line_item.unit_tax_amount == other_line_item.unit_tax_amount
+    assert other_transaction_line_item.discount_amount == other_line_item.discount_amount
+    assert other_transaction_line_item.product_code == other_line_item.product_code
+    assert other_transaction_line_item.commodity_code == other_line_item.commodity_code
+    assert other_transaction_line_item.url == other_line_item.url
+  end
+end


### PR DESCRIPTION
This creates the `TransactionLineItem` module and implements the `find_all/1` action as documented here: https://developers.braintreepayments.com/reference/response/transaction-line-item/ruby

Tried to mostly stick with the style of the codebase :p.