### PR TITLE
Add mapping for Gateway timeout

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -52,7 +52,8 @@ defmodule Braintree.HTTP do
     426 => :upgrade_required,
     429 => :too_many_requests,
     500 => :server_error,
-    503 => :service_unavailable
+    503 => :service_unavailable,
+    504 => :connect_timeout
   }
 
   @doc """


### PR DESCRIPTION
@sorentwo I haven't had a chance to really look into this one, but I've seen this error in our app a few times:

```
HTTP request error: no case clause matching: {:error, :connect_timeout}
...
(braintree) lib/client_token.ex:35: Braintree.ClientToken.generate/1
```

Looks like we include 504 status code [here](https://github.com/sorentwo/braintree-elixir/blob/master/lib/http.ex#L96) but do not have a `code_to_reason` mapping.

If this doesn't make sense I can dig a bit more. Thanks!