### PR TITLE
Fix typespecs

### DIFF
--- a/lib/add_on.ex
+++ b/lib/add_on.ex
@@ -44,7 +44,7 @@ defmodule Braintree.AddOn do
 
       {:ok, addons} = Braintree.AddOns.all()
   """
-  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def all(opts \\ []) do
     with {:ok, %{"add_ons" => add_ons}} <- HTTP.get("add_ons", opts) do
       {:ok, new(add_ons)}

--- a/lib/add_on.ex
+++ b/lib/add_on.ex
@@ -44,7 +44,8 @@ defmodule Braintree.AddOn do
 
       {:ok, addons} = Braintree.AddOns.all()
   """
-  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec all(Keyword.t()) ::
+          {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def all(opts \\ []) do
     with {:ok, %{"add_ons" => add_ons}} <- HTTP.get("add_ons", opts) do
       {:ok, new(add_ons)}

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -59,7 +59,7 @@ defmodule Braintree.Address do
 
     address.company # Braintree
   """
-  @spec create(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(customer_id, params \\ %{}, opts \\ []) when is_binary(customer_id) do
     with {:ok, payload} <-
            HTTP.post("customers/#{customer_id}/addresses/", %{address: params}, opts) do
@@ -74,7 +74,7 @@ defmodule Braintree.Address do
 
       :ok = Braintree.Address.delete("customer_id", "address_id")
   """
-  @spec delete(binary, binary, Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(binary, binary, Keyword.t()) :: :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(customer_id, id, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, _reponse} <- HTTP.delete("customers/#{customer_id}/addresses/" <> id, opts) do
       :ok
@@ -94,7 +94,7 @@ defmodule Braintree.Address do
 
       address.company # "New Company Name"
   """
-  @spec update(binary, binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(customer_id, id, params, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <-
            HTTP.put("customers/#{customer_id}/addresses/" <> id, %{address: params}, opts) do
@@ -110,7 +110,7 @@ defmodule Braintree.Address do
 
     address = Braintree.Address.find("customer_id", "address_id")
   """
-  @spec find(binary, binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(binary, binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(customer_id, id, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/#{customer_id}/addresses/" <> id, opts) do
       {:ok, new(payload)}

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -59,7 +59,8 @@ defmodule Braintree.Address do
 
     address.company # Braintree
   """
-  @spec create(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec create(binary, map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(customer_id, params \\ %{}, opts \\ []) when is_binary(customer_id) do
     with {:ok, payload} <-
            HTTP.post("customers/#{customer_id}/addresses/", %{address: params}, opts) do
@@ -74,7 +75,8 @@ defmodule Braintree.Address do
 
       :ok = Braintree.Address.delete("customer_id", "address_id")
   """
-  @spec delete(binary, binary, Keyword.t()) :: :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec delete(binary, binary, Keyword.t()) ::
+          :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(customer_id, id, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, _reponse} <- HTTP.delete("customers/#{customer_id}/addresses/" <> id, opts) do
       :ok
@@ -94,7 +96,8 @@ defmodule Braintree.Address do
 
       address.company # "New Company Name"
   """
-  @spec update(binary, binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec update(binary, binary, map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(customer_id, id, params, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <-
            HTTP.put("customers/#{customer_id}/addresses/" <> id, %{address: params}, opts) do
@@ -110,7 +113,8 @@ defmodule Braintree.Address do
 
     address = Braintree.Address.find("customer_id", "address_id")
   """
-  @spec find(binary, binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(binary, binary, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(customer_id, id, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/#{customer_id}/addresses/" <> id, opts) do
       {:ok, new(payload)}

--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -28,7 +28,8 @@ defmodule Braintree.ClientToken do
 
       {:ok, token} = Braintree.ClientToken.generate(%{version: 3})
   """
-  @spec generate(map, Keyword.t()) :: {:ok, binary} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec generate(map, Keyword.t()) ::
+          {:ok, binary} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def generate(params \\ %{}, opts \\ []) when is_map(params) do
     params = %{client_token: with_version(params)}
 

--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -28,7 +28,7 @@ defmodule Braintree.ClientToken do
 
       {:ok, token} = Braintree.ClientToken.generate(%{version: 3})
   """
-  @spec generate(map, Keyword.t()) :: {:ok, binary} | {:error, Error.t()}
+  @spec generate(map, Keyword.t()) :: {:ok, binary} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def generate(params \\ %{}, opts \\ []) when is_map(params) do
     params = %{client_token: with_version(params)}
 

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -64,7 +64,7 @@ defmodule Braintree.Customer do
 
       customer.company # Braintree
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("customers", %{customer: params}, opts) do
       {:ok, new(payload)}
@@ -80,7 +80,7 @@ defmodule Braintree.Customer do
 
       :ok = Braintree.Customer.delete("customer_id")
   """
-  @spec delete(binary, Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(binary, Keyword.t()) :: :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(id, opts \\ []) when is_binary(id) do
     with {:ok, _response} <- HTTP.delete("customers/" <> id, opts) do
       :ok
@@ -94,7 +94,7 @@ defmodule Braintree.Customer do
 
       customer = Braintree.Customer.find("customer_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/" <> id, opts) do
       {:ok, new(payload)}
@@ -114,7 +114,7 @@ defmodule Braintree.Customer do
 
       customer.company # "New Company Name"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("customers/" <> id, %{customer: params}, opts) do
       {:ok, new(payload)}

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -64,7 +64,8 @@ defmodule Braintree.Customer do
 
       customer.company # Braintree
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec create(map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("customers", %{customer: params}, opts) do
       {:ok, new(payload)}
@@ -80,7 +81,8 @@ defmodule Braintree.Customer do
 
       :ok = Braintree.Customer.delete("customer_id")
   """
-  @spec delete(binary, Keyword.t()) :: :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec delete(binary, Keyword.t()) ::
+          :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(id, opts \\ []) when is_binary(id) do
     with {:ok, _response} <- HTTP.delete("customers/" <> id, opts) do
       :ok
@@ -94,7 +96,8 @@ defmodule Braintree.Customer do
 
       customer = Braintree.Customer.find("customer_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(binary, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/" <> id, opts) do
       {:ok, new(payload)}
@@ -114,7 +117,8 @@ defmodule Braintree.Customer do
 
       customer.company # "New Company Name"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec update(binary, map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("customers/" <> id, %{customer: params}, opts) do
       {:ok, new(payload)}

--- a/lib/discount.ex
+++ b/lib/discount.ex
@@ -44,7 +44,7 @@ defmodule Braintree.Discount do
 
       {:ok, discounts} = Braintree.Discount.all()
   """
-  @spec all(Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec all(Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def all(opts \\ []) do
     with {:ok, payload} <- HTTP.get("discounts", opts) do
       %{"discounts" => discounts} = payload

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -24,7 +24,8 @@ defmodule Braintree.HTTP do
   alias Braintree.XML.{Decoder, Encoder}
 
   @type response ::
-          {:ok, map | {:error, atom}}
+          {:ok, map}
+          | {:error, atom()}
           | {:error, Error.t()}
           | {:error, binary}
 

--- a/lib/merchant/account.ex
+++ b/lib/merchant/account.ex
@@ -41,7 +41,8 @@ defmodule Braintree.Merchant.Account do
       tos_accepted: true,
     })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec create(map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <-
            HTTP.post("merchant_accounts/create_via_api", %{merchant_account: params}, opts) do
@@ -62,7 +63,8 @@ defmodule Braintree.Merchant.Account do
 
       merchant.funding_details.account_number # "1234567890"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec update(binary, map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(id, params, opts \\ []) when is_binary(id) do
     with {:ok, payload} <-
            HTTP.put("merchant_accounts/#{id}/update_via_api", %{merchant_account: params}, opts) do
@@ -77,7 +79,8 @@ defmodule Braintree.Merchant.Account do
 
     merchant = Braintree.Merchant.find("merchant_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(binary, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("merchant_accounts/" <> id, opts) do
       {:ok, new(payload)}

--- a/lib/merchant/account.ex
+++ b/lib/merchant/account.ex
@@ -41,7 +41,7 @@ defmodule Braintree.Merchant.Account do
       tos_accepted: true,
     })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <-
            HTTP.post("merchant_accounts/create_via_api", %{merchant_account: params}, opts) do
@@ -62,7 +62,7 @@ defmodule Braintree.Merchant.Account do
 
       merchant.funding_details.account_number # "1234567890"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(id, params, opts \\ []) when is_binary(id) do
     with {:ok, payload} <-
            HTTP.put("merchant_accounts/#{id}/update_via_api", %{merchant_account: params}, opts) do
@@ -77,7 +77,7 @@ defmodule Braintree.Merchant.Account do
 
     merchant = Braintree.Merchant.find("merchant_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("merchant_accounts/" <> id, opts) do
       {:ok, new(payload)}

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -26,7 +26,7 @@ defmodule Braintree.PaymentMethod do
       credit_card.type # "Visa"
   """
   @spec create(map, Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()}
+          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("payment_methods", %{payment_method: params}, opts) do
       {:ok, new(payload)}
@@ -58,7 +58,7 @@ defmodule Braintree.PaymentMethod do
       payment_method.cardholder_name # "NEW"
   """
   @spec update(String.t(), map, Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()}
+          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(token, params \\ %{}, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -74,7 +74,7 @@ defmodule Braintree.PaymentMethod do
 
       {:ok, "Success"} = Braintree.PaymentMethod.delete(token)
   """
-  @spec delete(String.t(), Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(String.t(), Keyword.t()) :: :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -93,7 +93,7 @@ defmodule Braintree.PaymentMethod do
       payment_method.type # CreditCard
   """
   @spec find(String.t(), Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()}
+          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -26,7 +26,11 @@ defmodule Braintree.PaymentMethod do
       credit_card.type # "Visa"
   """
   @spec create(map, Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+          {:ok, CreditCard.t()}
+          | {:ok, PaypalAccount.t()}
+          | {:error, Error.t()}
+          | {:error, atom()}
+          | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("payment_methods", %{payment_method: params}, opts) do
       {:ok, new(payload)}
@@ -58,7 +62,11 @@ defmodule Braintree.PaymentMethod do
       payment_method.cardholder_name # "NEW"
   """
   @spec update(String.t(), map, Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+          {:ok, CreditCard.t()}
+          | {:ok, PaypalAccount.t()}
+          | {:error, Error.t()}
+          | {:error, atom()}
+          | {:error, binary()}
   def update(token, params \\ %{}, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -74,7 +82,8 @@ defmodule Braintree.PaymentMethod do
 
       {:ok, "Success"} = Braintree.PaymentMethod.delete(token)
   """
-  @spec delete(String.t(), Keyword.t()) :: :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec delete(String.t(), Keyword.t()) ::
+          :ok | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -93,7 +102,11 @@ defmodule Braintree.PaymentMethod do
       payment_method.type # CreditCard
   """
   @spec find(String.t(), Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+          {:ok, CreditCard.t()}
+          | {:ok, PaypalAccount.t()}
+          | {:error, Error.t()}
+          | {:error, atom()}
+          | {:error, binary()}
   def find(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 

--- a/lib/payment_method_nonce.ex
+++ b/lib/payment_method_nonce.ex
@@ -39,7 +39,8 @@ defmodule Braintree.PaymentMethodNonce do
 
       payment_method_nonce.nonce
   """
-  @spec create(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec create(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(payment_method_token, opts \\ []) do
     path = "payment_methods/#{payment_method_token}/nonces"
 
@@ -57,7 +58,8 @@ defmodule Braintree.PaymentMethodNonce do
 
       payment_method.type #CreditCard
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(nonce, opts \\ []) do
     path = "payment_method_nonces/" <> nonce
 

--- a/lib/payment_method_nonce.ex
+++ b/lib/payment_method_nonce.ex
@@ -39,7 +39,7 @@ defmodule Braintree.PaymentMethodNonce do
 
       payment_method_nonce.nonce
   """
-  @spec create(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(payment_method_token, opts \\ []) do
     path = "payment_methods/#{payment_method_token}/nonces"
 
@@ -57,7 +57,7 @@ defmodule Braintree.PaymentMethodNonce do
 
       payment_method.type #CreditCard
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(nonce, opts \\ []) do
     path = "payment_method_nonces/" <> nonce
 

--- a/lib/paypal_account.ex
+++ b/lib/paypal_account.ex
@@ -42,7 +42,8 @@ defmodule Braintree.PaypalAccount do
 
       {:ok, paypal_account} = Braintree.PaypalAccount.find(token)
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(token, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 
@@ -62,7 +63,8 @@ defmodule Braintree.PaypalAccount do
         %{options: %{make_default: true}
       )
   """
-  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec update(String.t(), map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(token, params, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 
@@ -79,7 +81,8 @@ defmodule Braintree.PaypalAccount do
 
       {:ok, paypal_account} = Braintree.PaypalAccount.delete(token)
   """
-  @spec delete(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec delete(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(token, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 

--- a/lib/paypal_account.ex
+++ b/lib/paypal_account.ex
@@ -42,7 +42,7 @@ defmodule Braintree.PaypalAccount do
 
       {:ok, paypal_account} = Braintree.PaypalAccount.find(token)
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(token, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 
@@ -62,7 +62,7 @@ defmodule Braintree.PaypalAccount do
         %{options: %{make_default: true}
       )
   """
-  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(token, params, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 
@@ -79,7 +79,7 @@ defmodule Braintree.PaypalAccount do
 
       {:ok, paypal_account} = Braintree.PaypalAccount.delete(token)
   """
-  @spec delete(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec delete(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def delete(token, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 

--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -56,7 +56,7 @@ defmodule Braintree.Plan do
 
       {:ok, plans} = Braintree.Plan.all()
   """
-  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def all(opts \\ []) do
     with {:ok, %{"plans" => plans}} <- HTTP.get("plans", opts) do
       {:ok, new(plans)}

--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -56,7 +56,8 @@ defmodule Braintree.Plan do
 
       {:ok, plans} = Braintree.Plan.all()
   """
-  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec all(Keyword.t()) ::
+          {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def all(opts \\ []) do
     with {:ok, %{"plans" => plans}} <- HTTP.get("plans", opts) do
       {:ok, new(plans)}

--- a/lib/search.ex
+++ b/lib/search.ex
@@ -18,7 +18,8 @@ defmodule Braintree.Search do
     {:ok, customers} = Braintree.Search.perform(search_params, "customers", &Braintree.Customer.new/1)
 
   """
-  @spec perform(map, String.t(), fun(), Keyword.t()) :: {:ok, [any]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec perform(map, String.t(), fun(), Keyword.t()) ::
+          {:ok, [any]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def perform(params, resource, initializer, opts \\ []) when is_map(params) do
     with {:ok, payload} <- HTTP.post(resource <> "/advanced_search_ids", %{search: params}, opts) do
       fetch_all_records(payload, resource, initializer, opts)

--- a/lib/search.ex
+++ b/lib/search.ex
@@ -18,7 +18,7 @@ defmodule Braintree.Search do
     {:ok, customers} = Braintree.Search.perform(search_params, "customers", &Braintree.Customer.new/1)
 
   """
-  @spec perform(map, String.t(), fun(), Keyword.t()) :: {:ok, [any]} | {:error, Error.t()}
+  @spec perform(map, String.t(), fun(), Keyword.t()) :: {:ok, [any]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def perform(params, resource, initializer, opts \\ []) when is_map(params) do
     with {:ok, payload} <- HTTP.post(resource <> "/advanced_search_ids", %{search: params}, opts) do
       fetch_all_records(payload, resource, initializer, opts)

--- a/lib/settlement_batch_summary.ex
+++ b/lib/settlement_batch_summary.ex
@@ -65,7 +65,8 @@ defmodule Braintree.SettlementBatchSummary do
 
       Braintree.SettlementBatchSummary("2016-9-5", "custom_field_1")
   """
-  @spec generate(binary, binary | nil, Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec generate(binary, binary | nil, Keyword.t()) ::
+          {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def generate(settlement_date, custom_field \\ nil, opts \\ []) do
     criteria = build_criteria(settlement_date, custom_field)
     params = %{settlement_batch_summary: criteria}

--- a/lib/settlement_batch_summary.ex
+++ b/lib/settlement_batch_summary.ex
@@ -65,7 +65,7 @@ defmodule Braintree.SettlementBatchSummary do
 
       Braintree.SettlementBatchSummary("2016-9-5", "custom_field_1")
   """
-  @spec generate(binary, binary | nil, Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec generate(binary, binary | nil, Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def generate(settlement_date, custom_field \\ nil, opts \\ []) do
     criteria = build_criteria(settlement_date, custom_field)
     params = %{settlement_batch_summary: criteria}

--- a/lib/subscription.ex
+++ b/lib/subscription.ex
@@ -86,7 +86,7 @@ defmodule Braintree.Subscription do
         plan_id: "starter"
       })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("subscriptions", %{subscription: params}, opts) do
       {:ok, new(payload)}
@@ -100,7 +100,7 @@ defmodule Braintree.Subscription do
 
       {:ok, subscription} = Subscription.find("123")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(subscription_id, opts \\ []) do
     with {:ok, payload} <- HTTP.get("subscriptions/#{subscription_id}", opts) do
       {:ok, new(payload)}
@@ -115,7 +115,7 @@ defmodule Braintree.Subscription do
 
       {:ok, subscription} = Subscription.cancel("123")
   """
-  @spec cancel(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec cancel(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def cancel(subscription_id, opts \\ []) do
     with {:ok, payload} <- HTTP.put("subscriptions/#{subscription_id}/cancel", opts) do
       {:ok, new(payload)}
@@ -157,7 +157,7 @@ defmodule Braintree.Subscription do
       })
       subscription.plan_id # "new_plan_id"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("subscriptions/" <> id, %{subscription: params}, opts) do
       {:ok, new(payload)}

--- a/lib/subscription.ex
+++ b/lib/subscription.ex
@@ -86,7 +86,8 @@ defmodule Braintree.Subscription do
         plan_id: "starter"
       })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec create(map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("subscriptions", %{subscription: params}, opts) do
       {:ok, new(payload)}
@@ -100,7 +101,8 @@ defmodule Braintree.Subscription do
 
       {:ok, subscription} = Subscription.find("123")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(subscription_id, opts \\ []) do
     with {:ok, payload} <- HTTP.get("subscriptions/#{subscription_id}", opts) do
       {:ok, new(payload)}
@@ -115,7 +117,8 @@ defmodule Braintree.Subscription do
 
       {:ok, subscription} = Subscription.cancel("123")
   """
-  @spec cancel(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec cancel(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def cancel(subscription_id, opts \\ []) do
     with {:ok, payload} <- HTTP.put("subscriptions/#{subscription_id}/cancel", opts) do
       {:ok, new(payload)}
@@ -157,7 +160,8 @@ defmodule Braintree.Subscription do
       })
       subscription.plan_id # "new_plan_id"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec update(binary, map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("subscriptions/" <> id, %{subscription: params}, opts) do
       {:ok, new(payload)}

--- a/lib/testing/test_transaction.ex
+++ b/lib/testing/test_transaction.ex
@@ -19,7 +19,7 @@ defmodule Braintree.Testing.TestTransaction do
 
   transaction.status # "settled"
   """
-  @spec settle(String.t()) :: {:ok, any} | {:error, Error.t()}
+  @spec settle(String.t()) :: {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def settle(transaction_id) do
     path = "transactions/#{transaction_id}/settle"
 
@@ -36,7 +36,7 @@ defmodule Braintree.Testing.TestTransaction do
 
   transaction.status # "settlement_confirmed"
   """
-  @spec settlement_confirm(String.t()) :: {:ok, any} | {:error, Error.t()}
+  @spec settlement_confirm(String.t()) :: {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def settlement_confirm(transaction_id) do
     path = "transactions/#{transaction_id}/settlement_confirm"
 
@@ -53,7 +53,7 @@ defmodule Braintree.Testing.TestTransaction do
 
   transaction.status # "settlement_declined"
   """
-  @spec settlement_decline(String.t()) :: {:ok, any} | {:error, Error.t()}
+  @spec settlement_decline(String.t()) :: {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def settlement_decline(transaction_id) do
     path = "transactions/#{transaction_id}/settlement_decline"
 

--- a/lib/testing/test_transaction.ex
+++ b/lib/testing/test_transaction.ex
@@ -19,7 +19,8 @@ defmodule Braintree.Testing.TestTransaction do
 
   transaction.status # "settled"
   """
-  @spec settle(String.t()) :: {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec settle(String.t()) ::
+          {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def settle(transaction_id) do
     path = "transactions/#{transaction_id}/settle"
 
@@ -36,7 +37,8 @@ defmodule Braintree.Testing.TestTransaction do
 
   transaction.status # "settlement_confirmed"
   """
-  @spec settlement_confirm(String.t()) :: {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec settlement_confirm(String.t()) ::
+          {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def settlement_confirm(transaction_id) do
     path = "transactions/#{transaction_id}/settlement_confirm"
 
@@ -53,7 +55,8 @@ defmodule Braintree.Testing.TestTransaction do
 
   transaction.status # "settlement_declined"
   """
-  @spec settlement_decline(String.t()) :: {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec settlement_decline(String.t()) ::
+          {:ok, any} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def settlement_decline(transaction_id) do
     path = "transactions/#{transaction_id}/settlement_decline"
 

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -131,7 +131,8 @@ defmodule Braintree.Transaction do
 
       transaction.status # "settling"
   """
-  @spec sale(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec sale(map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def sale(params, opts \\ []) do
     sale_params = Map.merge(params, %{type: "sale"})
 
@@ -149,7 +150,8 @@ defmodule Braintree.Transaction do
       {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
       transaction.status # "settling"
   """
-  @spec submit_for_settlement(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec submit_for_settlement(String.t(), map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def submit_for_settlement(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/submit_for_settlement"
 
@@ -168,7 +170,8 @@ defmodule Braintree.Transaction do
 
       transaction.status # "refunded"
   """
-  @spec refund(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec refund(String.t(), map, Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def refund(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/refund"
 
@@ -186,7 +189,8 @@ defmodule Braintree.Transaction do
 
       transaction.status # "voided"
   """
-  @spec void(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec void(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def void(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}/void"
 
@@ -202,7 +206,8 @@ defmodule Braintree.Transaction do
 
       {:ok, transaction} = Transaction.find("123")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find(String.t(), Keyword.t()) ::
+          {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}"
 

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -131,7 +131,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "settling"
   """
-  @spec sale(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec sale(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def sale(params, opts \\ []) do
     sale_params = Map.merge(params, %{type: "sale"})
 
@@ -149,7 +149,7 @@ defmodule Braintree.Transaction do
       {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
       transaction.status # "settling"
   """
-  @spec submit_for_settlement(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec submit_for_settlement(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def submit_for_settlement(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/submit_for_settlement"
 
@@ -168,7 +168,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "refunded"
   """
-  @spec refund(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec refund(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def refund(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/refund"
 
@@ -186,7 +186,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "voided"
   """
-  @spec void(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec void(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def void(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}/void"
 
@@ -202,7 +202,7 @@ defmodule Braintree.Transaction do
 
       {:ok, transaction} = Transaction.find("123")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}"
 

--- a/lib/transaction_line_item.ex
+++ b/lib/transaction_line_item.ex
@@ -47,7 +47,7 @@ defmodule Braintree.TransactionLineItem do
 
       {:ok, transaction_line_items} = TransactionLineItem.find("123")
   """
-  @spec find_all(String.t(), Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec find_all(String.t(), Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find_all(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}/line_items"
 

--- a/lib/transaction_line_item.ex
+++ b/lib/transaction_line_item.ex
@@ -47,7 +47,8 @@ defmodule Braintree.TransactionLineItem do
 
       {:ok, transaction_line_items} = TransactionLineItem.find("123")
   """
-  @spec find_all(String.t(), Keyword.t()) :: {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
+  @spec find_all(String.t(), Keyword.t()) ::
+          {:ok, [t]} | {:error, Error.t()} | {:error, atom()} | {:error, binary()}
   def find_all(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}/line_items"
 


### PR DESCRIPTION
This is to update the typespecs for functions like `Subscription.update/3` which might return `{:error, :forbidden}`, because it passes through the error return from `HTTP.put`. The typespec for the `response` type in the `HTTP` module needs to be expanded, and then those functions that return the error returns from those various _request_ functions should be updated accordingly.

- [x] Fix the remaining occurrences if it seems that the initial round of changes is on track