### PR TITLE
Patch `Search.perform` to also work on transactions

### DIFF
--- a/lib/search.ex
+++ b/lib/search.ex
@@ -45,13 +45,15 @@ defmodule Braintree.Search do
     {:ok, records}
   end
 
-  # Credit card verification is an odd case because path to endpoints is
+  # Credit card verifications and transactions are an odd case because path to endpoints is
   # different from the object name in the XML.
-  defp fetch_records_chunk(ids, "verifications", initializer, opts) when is_list(ids) do
+  defp fetch_records_chunk(ids, resource, initializer, opts)
+       when is_list(ids) and resource in ~w(verifications transactions) do
     search_params = %{search: %{ids: ids}}
+    key_name = "credit_card_#{resource}"
 
-    with {:ok, %{"credit_card_verifications" => data}} <-
-           HTTP.post("verifications/advanced_search", search_params, opts) do
+    with {:ok, %{^key_name => data}} <-
+           HTTP.post(resource <> "/advanced_search", search_params, opts) do
       initializer.(data)
     end
   end


### PR DESCRIPTION
The `Search` module was not working for transactions. After some research I found out that `transactions` behave the same way as `verifications`, so I've extended the `fetch_records_chunk/4` function to work for transactions.

Before this line was blowing up:

```elixir
{:ok, transactions} = Braintree.Search.perform(%{ids: ["some-id-1", "some-id-2"]}, "transactions", &Braintree.Transaction.new/1)
```

and now it returns the results as intended.