### PR TITLE
Allow configuration of sandbox endpoint for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ testing][plp].
 [dtc]: https://articles.braintreepayments.com/control-panel/transactions/duplicate-checking
 [plp]: https://developers.braintreepayments.com/guides/paypal/testing-go-live/php#linked-paypal-testing
 
+### Testing Using Only `localhost`
+
+You can optionally configure the sandbox endpoint url to point towards a local url and
+port for testing which does not need to call out to the Braintree sandbox API.
+For example, in your `config.exs`
+```
+config :braintree, :sandbox_endpoint, "localhost:4001"
+```
+In conjuction with a libary such as [`Bypass`](https://github.com/PSPDFKit-labs/bypass)
+you can use this config to define test-specific returns from `Braintree` calls without
+hitting the Braintree sandbox API.
+
 ## License
 
 MIT License, see [LICENSE.txt](LICENSE.txt) for details.

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -28,10 +28,8 @@ defmodule Braintree.HTTP do
           | {:error, Error.t()}
           | {:error, binary}
 
-  @endpoints [
-    production: "https://api.braintreegateway.com/merchants/",
-    sandbox: "https://api.sandbox.braintreegateway.com/merchants/"
-  ]
+  @production_endpoint "https://api.braintreegateway.com/merchants/"
+  @sandbox_endpoint "https://api.sandbox.braintreegateway.com/merchants/"
 
   @cacertfile "/certs/api_braintreegateway_com.ca.crt"
 
@@ -131,7 +129,7 @@ defmodule Braintree.HTTP do
     environment = opts |> get_lazy_env(:environment) |> maybe_to_atom()
     merchant_id = get_lazy_env(opts, :merchant_id)
 
-    Keyword.fetch!(@endpoints, environment) <> merchant_id <> "/" <> path
+    Keyword.fetch!(endpoints(), environment) <> merchant_id <> "/" <> path
   end
 
   defp maybe_to_atom(value) when is_binary(value), do: String.to_existing_atom(value)
@@ -198,5 +196,17 @@ defmodule Braintree.HTTP do
 
   defp resolve_error_response(%{"unprocessable_entity" => _}) do
     Error.new(%{message: "Unprocessable Entity"})
+  end
+
+  defp endpoints do
+    [production: @production_endpoint, sandbox: sandbox_endpoint()]
+  end
+
+  defp sandbox_endpoint do
+    Application.get_env(
+      :braintree,
+      :sandbox_endpoint,
+      @sandbox_endpoint
+    )
   end
 end


### PR DESCRIPTION
I would like to be able to use [`Bypass`](https://github.com/PSPDFKit-labs/bypass) to test code that calls out to `Braintree`. Because the endpoints are hardcoded, this is not possible without modifying the library. I would prefer to not be using a fork of the library though, so this PR would solve that. 

All in all, this PR does the following:
* Allows sandbox endpoint configuration of `:braintree` with config key `:sandbox_endpoint` which uses `@sandbox_endpoint` if no config is provided
* Moves production endpoint definition to attribute `@production_endpoint`
* Builds keyword list at runtime to prevent stale config
* Updates `README.md` to inform library users of new config option