### PR TITLE
Add support for android pay card

### DIFF
--- a/lib/android_pay_card.ex
+++ b/lib/android_pay_card.ex
@@ -1,7 +1,10 @@
 defmodule Braintree.AndroidPayCard do
   @moduledoc """
   AndroidPayCard structs are not created directly, but are built within
-  responsees from other endpoints, such as `Braintree.Customer`.
+  responses from other endpoints, such as `Braintree.Customer`.
+  
+  For additional reference see:
+  https://developers.braintreepayments.com/reference/response/android-pay-card/ruby
   """
   use Braintree.Construction
 

--- a/lib/android_pay_card.ex
+++ b/lib/android_pay_card.ex
@@ -1,0 +1,46 @@
+defmodule Braintree.AndroidPayCard do
+  @moduledoc """
+  AndroidPayCard structs are not created directly, but are built within
+  responsees from other endpoints, such as `Braintree.Customer`.
+  """
+  use Braintree.Construction
+
+  @type t :: %__MODULE__{
+          bin: String.t(),
+          created_at: String.t(),
+          customer_id: String.t(),
+          default: boolean,
+          expiration_month: String.t(),
+          expiration_year: String.t(),
+          google_transaction_id: String.t(),
+          image_url: String.t(),
+          is_network_tokenized: boolean,
+          source_card_last_4: String.t(),
+          source_card_type: String.t(),
+          source_description: String.t(),
+          subscriptions: [any],
+          token: String.t(),
+          updated_at: String.t(),
+          virtual_card_last_4: String.t(),
+          virtual_card_type: String.t()
+        }
+
+  defstruct bin: nil,
+            billing_address: nil,
+            created_at: nil,
+            customer_id: nil,
+            default: false,
+            expiration_month: nil,
+            expiration_year: nil,
+            google_transaction_id: nil,
+            image_url: nil,
+            is_network_tokenized: false,
+            source_card_last_4: nil,
+            source_card_type: nil,
+            source_description: nil,
+            subscriptions: [],
+            token: nil,
+            updated_at: nil,
+            virtual_card_last_4: nil,
+            virtual_card_type: nil
+end

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -9,7 +9,7 @@ defmodule Braintree.Customer do
 
   use Braintree.Construction
 
-  alias Braintree.{ApplePayCard, CreditCard, HTTP, PaypalAccount, Search}
+  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount, Search}
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
@@ -25,6 +25,7 @@ defmodule Braintree.Customer do
           updated_at: String.t(),
           custom_fields: map,
           addresses: [map],
+          android_pay_cards: [AndroidPayCard.t()],
           apple_pay_cards: [ApplePayCard.t()],
           credit_cards: [CreditCard.t()],
           paypal_accounts: [PaypalAccount.t()],
@@ -43,6 +44,7 @@ defmodule Braintree.Customer do
             updated_at: nil,
             custom_fields: %{},
             addresses: [],
+            android_pay_cards: [],
             apple_pay_cards: [],
             credit_cards: [],
             coinbase_accounts: [],
@@ -154,7 +156,8 @@ defmodule Braintree.Customer do
 
     %{
       customer
-      | apple_pay_cards: ApplePayCard.new(customer.apple_pay_cards),
+      | android_pay_cards: AndroidPayCard.new(customer.android_pay_cards),
+        apple_pay_cards: ApplePayCard.new(customer.apple_pay_cards),
         credit_cards: CreditCard.new(customer.credit_cards),
         paypal_accounts: PaypalAccount.new(customer.paypal_accounts)
     }

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -4,7 +4,7 @@ defmodule Braintree.PaymentMethod do
   may be a `CreditCard` or a `PaypalAccount`.
   """
 
-  alias Braintree.{ApplePayCard, CreditCard, HTTP, PaypalAccount}
+  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount}
   alias Braintree.ErrorResponse, as: Error
 
   @doc """
@@ -102,7 +102,11 @@ defmodule Braintree.PaymentMethod do
     end
   end
 
-  @spec new(map) :: ApplePayCard.t() | CreditCard.t() | PaypalAccount.t()
+  @spec new(map) :: AndroidPayCard.t() | ApplePayCard.t() | CreditCard.t() | PaypalAccount.t()
+  defp new(%{"android_pay_card" => android_pay_card}) do
+    AndroidPayCard.new(android_pay_card)
+  end
+
   defp new(%{"apple_pay_card" => apple_pay_card}) do
     ApplePayCard.new(apple_pay_card)
   end

--- a/test/customer_test.exs
+++ b/test/customer_test.exs
@@ -27,6 +27,28 @@ defmodule Braintree.CustomerTest do
       Customer.new(%{
         "company" => "Soren",
         "email" => "parker@example.com",
+        "android_pay_cards" => [
+          %{
+            "bin" => "401288",
+            "created_at" => "2020-08-13T22:13:55Z",
+            "customer_id" => "225954129",
+            "default" => false,
+            "expiration_month" => "12",
+            "expiration_year" => "2020",
+            "google_transaction_id" => "123",
+            "image_url" =>
+              "https://assets.braintreegateway.com/payment_method_logo/apple_pay.png?environment=sandbox",
+            "is_network_tokenized" => false,
+            "source_card_last_4" => "1881",
+            "source_card_type" => "Android Pay - Visa",
+            "source_description" => "Visa 8886",
+            "subscriptions" => [],
+            "token" => "mrt2ptb",
+            "updated_at" => "2020-08-13T22:13:55Z",
+            "virtual_card_last_4" => nil,
+            "virtual_card_type" => nil
+          }
+        ],
         "apple_pay_cards" => [
           %{
             "billing_address" => %{"postal_code" => "222222"},
@@ -65,9 +87,33 @@ defmodule Braintree.CustomerTest do
         ]
       })
 
+    assert Enum.any?(customer.android_pay_cards)
     assert Enum.any?(customer.apple_pay_cards)
     assert Enum.any?(customer.credit_cards)
     assert Enum.any?(customer.paypal_accounts)
+
+    [android_pay_card] = customer.android_pay_cards
+
+    assert android_pay_card == %Braintree.AndroidPayCard{
+             bin: "401288",
+             created_at: "2020-08-13T22:13:55Z",
+             customer_id: "225954129",
+             default: false,
+             expiration_month: "12",
+             expiration_year: "2020",
+             google_transaction_id: "123",
+             image_url:
+               "https://assets.braintreegateway.com/payment_method_logo/apple_pay.png?environment=sandbox",
+             is_network_tokenized: false,
+             source_card_last_4: "1881",
+             source_card_type: "Android Pay - Visa",
+             source_description: "Visa 8886",
+             subscriptions: [],
+             token: "mrt2ptb",
+             updated_at: "2020-08-13T22:13:55Z",
+             virtual_card_last_4: nil,
+             virtual_card_type: nil
+           }
 
     [apple_pay_card] = customer.apple_pay_cards
 

--- a/test/integration/payment_method_test.exs
+++ b/test/integration/payment_method_test.exs
@@ -1,4 +1,5 @@
 defmodule Braintree.Integration.PaymentMethodTest do
+  @moduledoc false
   use ExUnit.Case, async: true
 
   alias Braintree.{Customer, PaymentMethod, PaymentMethodNonce}
@@ -103,6 +104,40 @@ defmodule Braintree.Integration.PaymentMethodTest do
              PaymentMethod.create(%{
                customer_id: customer_id,
                payment_method_nonce: Nonces.apple_pay_visa()
+             })
+  end
+
+  test "create/1 can create an AndroidPay payment method" do
+    {:ok, %{id: customer_id}} =
+      Customer.create(%{
+        first_name: "Rick",
+        last_name: "Grimes"
+      })
+
+    assert {:ok,
+            %Braintree.AndroidPayCard{
+              bin: "401288",
+              created_at: "" <> _,
+              customer_id: ^customer_id,
+              default: true,
+              expiration_month: "12",
+              expiration_year: "2025",
+              google_transaction_id: "google_transaction_id",
+              image_url:
+                "https://assets.braintreegateway.com/payment_method_logo/android_pay_card.png?environment=sandbox",
+              is_network_tokenized: true,
+              source_card_last_4: "1111",
+              source_card_type: "Visa",
+              source_description: "Visa 1111",
+              subscriptions: [],
+              token: "" <> _,
+              updated_at: "" <> _,
+              virtual_card_last_4: "1881",
+              virtual_card_type: "Visa"
+            }} =
+             PaymentMethod.create(%{
+               customer_id: customer_id,
+               payment_method_nonce: Nonces.android_pay_visa_nonce()
              })
   end
 

--- a/test/integration/payment_method_test.exs
+++ b/test/integration/payment_method_test.exs
@@ -1,5 +1,4 @@
 defmodule Braintree.Integration.PaymentMethodTest do
-  @moduledoc false
   use ExUnit.Case, async: true
 
   alias Braintree.{Customer, PaymentMethod, PaymentMethodNonce}


### PR DESCRIPTION
We have integrated with Google Ordering and customers pay with Google Pay. This PR adds support for this payment type.