### PR TITLE
Change Braintree.fetch_env! to Braintree.get_env on Braintree.Webhook.Validation

### DIFF
--- a/lib/webhook/validation.ex
+++ b/lib/webhook/validation.ex
@@ -41,6 +41,6 @@ defmodule Braintree.Webhook.Validation do
     Digest.secure_compare(signature, payload_signature)
   end
 
-  defp braintree_public_key(), do: Braintree.fetch_env!(:public_key)
-  defp braintree_private_key(), do: Braintree.fetch_env!(:private_key)
+  defp braintree_public_key(), do: Braintree.get_env(:public_key)
+  defp braintree_private_key(), do: Braintree.get_env(:private_key)
 end


### PR DESCRIPTION
Related issue: https://github.com/sorentwo/braintree-elixir/issues/118

Change non-existing Braintree.fetch_env! to Braintree.get_env.
Braintree.get_env/1 throw error when searched env is not found, so its behavior should match the original code's intention