### PR TITLE
Support ACH Direct Debit payment methods

### DIFF
--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -9,7 +9,7 @@ defmodule Braintree.Customer do
 
   use Braintree.Construction
 
-  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount, Search}
+  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount, Search, UsBankAccount}
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
@@ -29,7 +29,8 @@ defmodule Braintree.Customer do
           apple_pay_cards: [ApplePayCard.t()],
           credit_cards: [CreditCard.t()],
           paypal_accounts: [PaypalAccount.t()],
-          coinbase_accounts: [map]
+          coinbase_accounts: [map],
+          us_bank_accounts: [UsBankAccount.t()]
         }
 
   defstruct id: nil,
@@ -48,7 +49,8 @@ defmodule Braintree.Customer do
             apple_pay_cards: [],
             credit_cards: [],
             coinbase_accounts: [],
-            paypal_accounts: []
+            paypal_accounts: [],
+            us_bank_accounts: []
 
   @doc """
   Create a customer record, or return an error response with after failed
@@ -159,7 +161,8 @@ defmodule Braintree.Customer do
       | android_pay_cards: AndroidPayCard.new(customer.android_pay_cards),
         apple_pay_cards: ApplePayCard.new(customer.apple_pay_cards),
         credit_cards: CreditCard.new(customer.credit_cards),
-        paypal_accounts: PaypalAccount.new(customer.paypal_accounts)
+        paypal_accounts: PaypalAccount.new(customer.paypal_accounts),
+        us_bank_accounts: UsBankAccount.new(customer.us_bank_accounts)
     }
   end
 

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -4,7 +4,7 @@ defmodule Braintree.PaymentMethod do
   may be a `CreditCard` or a `PaypalAccount`.
   """
 
-  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount}
+  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount, UsBankAccount}
   alias Braintree.ErrorResponse, as: Error
 
   @doc """
@@ -26,7 +26,10 @@ defmodule Braintree.PaymentMethod do
       credit_card.type # "Visa"
   """
   @spec create(map, Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()}
+          {:ok, CreditCard.t()}
+          | {:ok, PaypalAccount.t()}
+          | {:ok, UsBankAccount.t()}
+          | {:error, Error.t()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("payment_methods", %{payment_method: params}, opts) do
       {:ok, new(payload)}
@@ -93,7 +96,10 @@ defmodule Braintree.PaymentMethod do
       payment_method.type # CreditCard
   """
   @spec find(String.t(), Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()}
+          {:ok, CreditCard.t()}
+          | {:ok, PaypalAccount.t()}
+          | {:ok, UsBankAccount.t()}
+          | {:error, Error.t()}
   def find(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -102,7 +108,7 @@ defmodule Braintree.PaymentMethod do
     end
   end
 
-  @spec new(map) :: AndroidPayCard.t() | ApplePayCard.t() | CreditCard.t() | PaypalAccount.t()
+  @spec new(map) :: AndroidPayCard.t() | ApplePayCard.t() | CreditCard.t() | PaypalAccount.t() | UsBankAccount.t()
   defp new(%{"android_pay_card" => android_pay_card}) do
     AndroidPayCard.new(android_pay_card)
   end
@@ -117,5 +123,9 @@ defmodule Braintree.PaymentMethod do
 
   defp new(%{"paypal_account" => paypal_account}) do
     PaypalAccount.new(paypal_account)
+  end
+
+  defp new(%{"us_bank_account" => us_bank_account}) do
+    UsBankAccount.new(us_bank_account)
   end
 end

--- a/lib/us_bank_account.ex
+++ b/lib/us_bank_account.ex
@@ -1,0 +1,58 @@
+defmodule Braintree.UsBankAccount do
+  @moduledoc """
+  UsBankAccount structs are not created directly, but are built within
+  responses from other endpoints, such as `Braintree.Customer`.
+  """
+
+  use Braintree.Construction
+
+  @type t :: %__MODULE__{
+          account_number: String.t(),
+          account_type: String.t(),
+          ach_mandate: map(),
+          bank_name: String.t(),
+          business_name: String.t(),
+          customer_id: String.t(),
+          customer_global_id: String.t(),
+          account_holder_name: String.t(),
+          default: String.t(),
+          first_name: String.t(),
+          global_id: String.t(),
+          image_url: String.t(),
+          last_4: String.t(),
+          last_name: String.t(),
+          ownership_type: String.t(),
+          routing_number: String.t(),
+          token: String.t(),
+          vaulted_in_blue: String.t(),
+          verifications: [any],
+          verified: boolean,
+          verified_by: String.t(),
+          created_at: String.t(),
+          updated_at: String.t()
+        }
+
+  defstruct account_number: nil,
+            account_type: nil,
+            ach_mandate: nil,
+            bank_name: nil,
+            business_name: nil,
+            customer_id: nil,
+            customer_global_id: nil,
+            account_holder_name: nil,
+            default: nil,
+            first_name: nil,
+            global_id: nil,
+            image_url: nil,
+            last_4: nil,
+            last_name: nil,
+            ownership_type: nil,
+            routing_number: nil,
+            token: nil,
+            vaulted_in_blue: nil,
+            verifications: [],
+            verified: nil,
+            verified_by: nil,
+            created_at: nil,
+            updated_at: nil
+end


### PR DESCRIPTION
Some time ago I needed to support the ACH Direct Debit payment method

https://developer.paypal.com/braintree/docs/guides/ach/server-side
https://developer.paypal.com/braintree/docs/reference/response/us-bank-account/ruby

I'd be glad to add `UsBankAccount` struct to the master repo, in case someone would need this too

appreciate for review! thanks! 