### PR TITLE
Fix error type in HTTP response type specification

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -24,7 +24,8 @@ defmodule Braintree.HTTP do
   alias Braintree.XML.{Decoder, Encoder}
 
   @type response ::
-          {:ok, map | {:error, atom}}
+          {:ok, map}
+          | {:error, atom}
           | {:error, Error.t()}
           | {:error, binary}
 


### PR DESCRIPTION
This typespec error isn't caught given the current dialyzer settings but will cause issues for clients expecting things like `{:error, :not_found}` which yield dialyzer warnings because it will trust the exported type here. There are some other improvements that can be made if you turn on `:underspecs` but it depends on how precise you want your specs to be.