### PR TITLE
allow passing options to webhook parser

### DIFF
--- a/lib/webhook.ex
+++ b/lib/webhook.ex
@@ -8,12 +8,14 @@ defmodule Braintree.Webhook do
   @doc """
   Return a map containing the payload and signature from the braintree webhook event.
   """
-  @spec parse(String.t() | nil, String.t() | nil) :: {:ok, map} | {:error, String.t()}
-  def parse(nil, _payload), do: {:error, "Signature cannot be nil"}
-  def parse(_sig, nil), do: {:error, "Payload cannot be nil"}
+  @spec parse(String.t() | nil, String.t() | nil, Keyword.t()) ::
+          {:ok, map} | {:error, String.t()}
+  def parse(signature, payload, opts \\ [])
+  def parse(nil, _payload, _opts), do: {:error, "Signature cannot be nil"}
+  def parse(_sig, nil, _opts), do: {:error, "Payload cannot be nil"}
 
-  def parse(sig, payload) do
-    with :ok <- Validation.validate_signature(sig, payload),
+  def parse(sig, payload, opts) do
+    with :ok <- Validation.validate_signature(sig, payload, opts),
          {:ok, decoded} <- Base.decode64(payload, ignore: :whitespace) do
       {:ok, %{"payload" => decoded, "signature" => sig}}
     else

--- a/lib/webhook/validation.ex
+++ b/lib/webhook/validation.ex
@@ -8,40 +8,42 @@ defmodule Braintree.Webhook.Validation do
   @doc """
   Validate the webhook signature and payload from braintree.
   """
-  @spec validate_signature(String.t() | nil, String.t() | nil) :: :ok | {:error, String.t()}
-  def validate_signature(nil, _payload), do: {:error, "Signature cannot be nil"}
-  def validate_signature(_sig, nil), do: {:error, "Payload cannot be nil"}
+  @spec validate_signature(String.t() | nil, String.t() | nil, Keyword.t()) ::
+          :ok | {:error, String.t()}
+  def validate_signature(signature, payload, opts \\ [])
+  def validate_signature(nil, _payload, _opts), do: {:error, "Signature cannot be nil"}
+  def validate_signature(_sig, nil, _opts), do: {:error, "Payload cannot be nil"}
 
-  def validate_signature(sig, payload) do
+  def validate_signature(sig, payload, opts) do
     sig
-    |> matching_sig_pair()
-    |> compare_sig_pair(payload)
+    |> matching_sig_pair(opts)
+    |> compare_sig_pair(payload, opts)
   end
 
-  defp matching_sig_pair(sig_string) do
+  defp matching_sig_pair(sig_string, opts) do
     sig_string
     |> String.split("&")
     |> Enum.filter(&String.contains?(&1, "|"))
     |> Enum.map(&String.split(&1, "|"))
-    |> Enum.find([], fn [public_key, _signature] -> public_key == braintree_public_key() end)
+    |> Enum.find([], fn [public_key, _signature] -> public_key == braintree_public_key(opts) end)
   end
 
-  defp compare_sig_pair([], _), do: {:error, "No matching public key"}
+  defp compare_sig_pair([], _, _), do: {:error, "No matching public key"}
 
-  defp compare_sig_pair([_public_key, sig], payload) do
-    if Enum.any?([payload, payload <> "\n"], &secure_compare(sig, &1)) do
+  defp compare_sig_pair([_public_key, sig], payload, opts) do
+    if Enum.any?([payload, payload <> "\n"], &secure_compare(sig, &1, opts)) do
       :ok
     else
       {:error, "Signature does not match payload, one has been modified"}
     end
   end
 
-  defp secure_compare(signature, payload) do
-    payload_signature = Digest.hexdigest(braintree_private_key(), payload)
+  defp secure_compare(signature, payload, opts) do
+    payload_signature = Digest.hexdigest(braintree_private_key(opts), payload)
 
     Digest.secure_compare(signature, payload_signature)
   end
 
-  defp braintree_public_key, do: Braintree.get_env(:public_key)
-  defp braintree_private_key, do: Braintree.get_env(:private_key)
+  defp braintree_public_key(opts), do: Braintree.get_env(:public_key, opts[:public_key])
+  defp braintree_private_key(opts), do: Braintree.get_env(:private_key, opts[:private_key])
 end

--- a/lib/webhook/validation.ex
+++ b/lib/webhook/validation.ex
@@ -44,6 +44,9 @@ defmodule Braintree.Webhook.Validation do
     Digest.secure_compare(signature, payload_signature)
   end
 
-  defp braintree_public_key(opts), do: Braintree.get_env(:public_key, opts[:public_key])
-  defp braintree_private_key(opts), do: Braintree.get_env(:private_key, opts[:private_key])
+  defp braintree_public_key(opts),
+    do: Keyword.get_lazy(opts, :public_key, fn -> Braintree.get_env(:public_key) end)
+
+  defp braintree_private_key(opts),
+    do: Keyword.get_lazy(opts, :private_key, fn -> Braintree.get_env(:private_key) end)
 end


### PR DESCRIPTION
I added a way to pass options to the webhook parser/validator, similar to other API functions.