### PR TITLE
Update Customer.find/2 typespec

### DIFF
--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -109,7 +109,7 @@ defmodule Braintree.Customer do
 
       customer = Braintree.Customer.find("customer_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, :not_found | Error.t()}
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/" <> id, opts) do
       {:ok, new(payload)}


### PR DESCRIPTION
Fix for Dialyzer error related to missing `{:error, :not_found}` response type for `Customer.find/2`