### PR TITLE
Fix typespec on ClientToken.generate/2

### DIFF
--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -28,7 +28,7 @@ defmodule Braintree.ClientToken do
 
       {:ok, token} = Braintree.ClientToken.generate(%{version: 3})
   """
-  @spec generate(map, Keyword.t()) :: {:ok, binary} | {:error, Error.t()}
+  @spec generate(map, Keyword.t()) :: {:ok, binary} | HTTP.error()
   def generate(params \\ %{}, opts \\ []) when is_map(params) do
     params = %{client_token: with_version(params)}
 

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -23,11 +23,12 @@ defmodule Braintree.HTTP do
   alias Braintree.ErrorResponse, as: Error
   alias Braintree.XML.{Decoder, Encoder}
 
-  @type response ::
-          {:ok, map}
-          | {:error, atom}
+  @type error ::
+          {:error, atom}
           | {:error, Error.t()}
           | {:error, binary}
+
+  @type response :: {:ok, map} | error
 
   @production_endpoint "https://api.braintreegateway.com/merchants/"
   @sandbox_endpoint "https://api.sandbox.braintreegateway.com/merchants/"

--- a/test/client_token_test.exs
+++ b/test/client_token_test.exs
@@ -1,0 +1,53 @@
+defmodule Braintree.ClientTokenTest do
+  # Don't test asynchronously in this file. It relies on Bypass.
+  use ExUnit.Case
+
+  import Braintree.Test.Support.ConfigHelper
+
+  alias Braintree.{ClientToken, ErrorResponse}
+
+  @error_gzip :zlib.gzip("""
+              <?xml version="1.0" encoding="UTF-8"?>
+              <api-error-response>
+                <message>Test Error.</message>
+              </api-error-response>
+              """)
+
+  describe "generate/1" do
+    test "returns an ErrorResponse when the API responds with 422" do
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 422, @error_gzip)
+      end)
+
+      with_applicaton_config(:sandbox_endpoint, "localhost:#{bypass.port}/", fn ->
+        assert {
+                 :error,
+                 %ErrorResponse{message: "Test Error."}
+               } = ClientToken.generate()
+      end)
+    end
+
+    test "returns an error tuple with a code when the response is not 200 or 422" do
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 500, "Something went wrong")
+      end)
+
+      with_applicaton_config(:sandbox_endpoint, "localhost:#{bypass.port}/", fn ->
+        assert {:error, :server_error} = ClientToken.generate()
+      end)
+    end
+
+    test "returns an error tuple with a code when the connection fails" do
+      bypass = Bypass.open()
+      Bypass.down(bypass)
+
+      with_applicaton_config(:sandbox_endpoint, "localhost:#{bypass.port}/", fn ->
+        assert {:error, :econnrefused} = ClientToken.generate()
+      end)
+    end
+  end
+end

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -1,6 +1,7 @@
 defmodule Braintree.HTTPTest do
   use ExUnit.Case
 
+  import Braintree.Test.Support.ConfigHelper
   import ExUnit.CaptureLog
 
   alias Braintree.{ConfigError, HTTP}
@@ -197,20 +198,6 @@ defmodule Braintree.HTTPTest do
       assert_raise ConfigError, "missing config for :#{key}", fun
     after
       Braintree.put_env(key, value)
-    end
-  end
-
-  defp with_applicaton_config(key, value, fun) do
-    original = Braintree.get_env(key, :none)
-
-    try do
-      Braintree.put_env(key, value)
-      fun.()
-    after
-      case original do
-        :none -> Application.delete_env(:braintree, key)
-        _ -> Braintree.put_env(key, original)
-      end
     end
   end
 end

--- a/test/support/config_helper.ex
+++ b/test/support/config_helper.ex
@@ -1,0 +1,15 @@
+defmodule Braintree.Test.Support.ConfigHelper do
+  def with_applicaton_config(key, value, fun) do
+    original = Braintree.get_env(key, :none)
+
+    try do
+      Braintree.put_env(key, value)
+      fun.()
+    after
+      case original do
+        :none -> Application.delete_env(:braintree, key)
+        _ -> Braintree.put_env(key, original)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I discovered  that the typespec on `Braintree.ClientToken.generate/2` defines it's error tuple as `{:error, ErrorResponse.t()`. However that is only returned when the API responds with `422`. In a project I used this for I had to add a dialyzer ignore entry to avoid an error. 

This updates the typespec to match what the `HTTP` module returns.