### PR TITLE
Fix specs for functions returning HTTP errors

### DIFF
--- a/lib/add_on.ex
+++ b/lib/add_on.ex
@@ -12,7 +12,6 @@ defmodule Braintree.AddOn do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -44,7 +43,7 @@ defmodule Braintree.AddOn do
 
       {:ok, addons} = Braintree.AddOns.all()
   """
-  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec all(Keyword.t()) :: {:ok, [t]} | HTTP.error()
   def all(opts \\ []) do
     with {:ok, %{"add_ons" => add_ons}} <- HTTP.get("add_ons", opts) do
       {:ok, new(add_ons)}

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -9,7 +9,6 @@ defmodule Braintree.Address do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -59,7 +58,7 @@ defmodule Braintree.Address do
 
     address.company # Braintree
   """
-  @spec create(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(binary, map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def create(customer_id, params \\ %{}, opts \\ []) when is_binary(customer_id) do
     with {:ok, payload} <-
            HTTP.post("customers/#{customer_id}/addresses/", %{address: params}, opts) do
@@ -74,7 +73,7 @@ defmodule Braintree.Address do
 
       :ok = Braintree.Address.delete("customer_id", "address_id")
   """
-  @spec delete(binary, binary, Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(binary, binary, Keyword.t()) :: :ok | HTTP.error()
   def delete(customer_id, id, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, _reponse} <- HTTP.delete("customers/#{customer_id}/addresses/" <> id, opts) do
       :ok
@@ -94,7 +93,7 @@ defmodule Braintree.Address do
 
       address.company # "New Company Name"
   """
-  @spec update(binary, binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, binary, map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def update(customer_id, id, params, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <-
            HTTP.put("customers/#{customer_id}/addresses/" <> id, %{address: params}, opts) do
@@ -110,7 +109,7 @@ defmodule Braintree.Address do
 
     address = Braintree.Address.find("customer_id", "address_id")
   """
-  @spec find(binary, binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(binary, binary, Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(customer_id, id, opts \\ []) when is_binary(customer_id) and is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/#{customer_id}/addresses/" <> id, opts) do
       {:ok, new(payload)}

--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -6,7 +6,6 @@ defmodule Braintree.ClientToken do
   https://developers.braintreepayments.com/reference/request/client-token/generate/ruby
   """
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @version 2

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -19,8 +19,6 @@ defmodule Braintree.Customer do
     UsBankAccount
   }
 
-  alias Braintree.ErrorResponse, as: Error
-
   @type t :: %__MODULE__{
           id: String.t(),
           company: String.t(),
@@ -79,7 +77,7 @@ defmodule Braintree.Customer do
 
       customer.company # Braintree
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("customers", %{customer: params}, opts) do
       {:ok, new(payload)}
@@ -95,7 +93,7 @@ defmodule Braintree.Customer do
 
       :ok = Braintree.Customer.delete("customer_id")
   """
-  @spec delete(binary, Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(binary, Keyword.t()) :: :ok | HTTP.error()
   def delete(id, opts \\ []) when is_binary(id) do
     with {:ok, _response} <- HTTP.delete("customers/" <> id, opts) do
       :ok
@@ -109,7 +107,7 @@ defmodule Braintree.Customer do
 
       customer = Braintree.Customer.find("customer_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, :not_found | Error.t()}
+  @spec find(binary, Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("customers/" <> id, opts) do
       {:ok, new(payload)}
@@ -129,7 +127,7 @@ defmodule Braintree.Customer do
 
       customer.company # "New Company Name"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("customers/" <> id, %{customer: params}, opts) do
       {:ok, new(payload)}
@@ -144,7 +142,7 @@ defmodule Braintree.Customer do
 
       {:ok, customers} = Braintree.Customer.search(%{first_name: %{is: "Jenna"}})
   """
-  @spec search(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec search(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def search(params, opts \\ []) when is_map(params) do
     Search.perform(params, "customers", &new/1, opts)
   end

--- a/lib/discount.ex
+++ b/lib/discount.ex
@@ -12,7 +12,6 @@ defmodule Braintree.Discount do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -44,7 +43,7 @@ defmodule Braintree.Discount do
 
       {:ok, discounts} = Braintree.Discount.all()
   """
-  @spec all(Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec all(Keyword.t()) :: {:ok, t} | HTTP.error()
   def all(opts \\ []) do
     with {:ok, payload} <- HTTP.get("discounts", opts) do
       %{"discounts" => discounts} = payload

--- a/lib/merchant/account.ex
+++ b/lib/merchant/account.ex
@@ -8,7 +8,6 @@ defmodule Braintree.Merchant.Account do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
   alias Braintree.Merchant.{Business, Funding, Individual}
 
@@ -41,7 +40,7 @@ defmodule Braintree.Merchant.Account do
       tos_accepted: true,
     })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <-
            HTTP.post("merchant_accounts/create_via_api", %{merchant_account: params}, opts) do
@@ -62,7 +61,7 @@ defmodule Braintree.Merchant.Account do
 
       merchant.funding_details.account_number # "1234567890"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def update(id, params, opts \\ []) when is_binary(id) do
     with {:ok, payload} <-
            HTTP.put("merchant_accounts/#{id}/update_via_api", %{merchant_account: params}, opts) do
@@ -77,7 +76,7 @@ defmodule Braintree.Merchant.Account do
 
     merchant = Braintree.Merchant.find("merchant_id")
   """
-  @spec find(binary, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(binary, Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, payload} <- HTTP.get("merchant_accounts/" <> id, opts) do
       {:ok, new(payload)}

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -4,8 +4,15 @@ defmodule Braintree.PaymentMethod do
   may be a `CreditCard` or a `PaypalAccount`.
   """
 
-  alias Braintree.{AndroidPayCard, ApplePayCard, CreditCard, HTTP, PaypalAccount, UsBankAccount, VenmoAccount}
-  alias Braintree.ErrorResponse, as: Error
+  alias Braintree.{
+    AndroidPayCard,
+    ApplePayCard,
+    CreditCard,
+    HTTP,
+    PaypalAccount,
+    UsBankAccount,
+    VenmoAccount
+  }
 
   @doc """
   Create a payment method record, or return an error response with after failed
@@ -30,7 +37,7 @@ defmodule Braintree.PaymentMethod do
           | {:ok, PaypalAccount.t()}
           | {:ok, UsBankAccount.t()}
           | {:ok, VenmoAccount.t()}
-          | {:error, Error.t()}
+          | HTTP.error()
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("payment_methods", %{payment_method: params}, opts) do
       {:ok, new(payload)}
@@ -62,7 +69,7 @@ defmodule Braintree.PaymentMethod do
       payment_method.cardholder_name # "NEW"
   """
   @spec update(String.t(), map, Keyword.t()) ::
-          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | {:error, Error.t()}
+          {:ok, CreditCard.t()} | {:ok, PaypalAccount.t()} | HTTP.error()
   def update(token, params \\ %{}, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -78,7 +85,7 @@ defmodule Braintree.PaymentMethod do
 
       {:ok, "Success"} = Braintree.PaymentMethod.delete(token)
   """
-  @spec delete(String.t(), Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(String.t(), Keyword.t()) :: :ok | HTTP.error()
   def delete(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 
@@ -100,7 +107,7 @@ defmodule Braintree.PaymentMethod do
           {:ok, CreditCard.t()}
           | {:ok, PaypalAccount.t()}
           | {:ok, UsBankAccount.t()}
-          | {:error, Error.t()}
+          | HTTP.error()
   def find(token, opts \\ []) do
     path = "payment_methods/any/" <> token
 

--- a/lib/payment_method_nonce.ex
+++ b/lib/payment_method_nonce.ex
@@ -5,7 +5,6 @@ defmodule Braintree.PaymentMethodNonce do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -39,7 +38,7 @@ defmodule Braintree.PaymentMethodNonce do
 
       payment_method_nonce.nonce
   """
-  @spec create(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def create(payment_method_token, opts \\ []) do
     path = "payment_methods/#{payment_method_token}/nonces"
 
@@ -57,7 +56,7 @@ defmodule Braintree.PaymentMethodNonce do
 
       payment_method.type #CreditCard
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(nonce, opts \\ []) do
     path = "payment_method_nonces/" <> nonce
 

--- a/lib/paypal_account.ex
+++ b/lib/paypal_account.ex
@@ -5,7 +5,6 @@ defmodule Braintree.PaypalAccount do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -42,7 +41,7 @@ defmodule Braintree.PaypalAccount do
 
       {:ok, paypal_account} = Braintree.PaypalAccount.find(token)
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(token, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 
@@ -62,7 +61,7 @@ defmodule Braintree.PaypalAccount do
         %{options: %{make_default: true}
       )
   """
-  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def update(token, params, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 
@@ -79,7 +78,7 @@ defmodule Braintree.PaypalAccount do
 
       {:ok, paypal_account} = Braintree.PaypalAccount.delete(token)
   """
-  @spec delete(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec delete(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def delete(token, opts \\ []) do
     path = "payment_methods/paypal_account/" <> token
 

--- a/lib/plan.ex
+++ b/lib/plan.ex
@@ -9,7 +9,6 @@ defmodule Braintree.Plan do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -56,7 +55,7 @@ defmodule Braintree.Plan do
 
       {:ok, plans} = Braintree.Plan.all()
   """
-  @spec all(Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec all(Keyword.t()) :: {:ok, [t]} | HTTP.error()
   def all(opts \\ []) do
     with {:ok, %{"plans" => plans}} <- HTTP.get("plans", opts) do
       {:ok, new(plans)}
@@ -75,7 +74,7 @@ defmodule Braintree.Plan do
         price: "10.00"
       })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def create(params, opts \\ []) do
     with {:ok, %{"plan" => plan}} <- HTTP.post("plans", %{plan: params}, opts) do
       {:ok, new(plan)}
@@ -92,7 +91,7 @@ defmodule Braintree.Plan do
 
       {:error, :not_found} = Braintree.Plan.find("non-existing plan_id")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(id, opts \\ []) when is_binary(id) do
     with {:ok, %{"plan" => plan}} <- HTTP.get("plans/#{id}", opts) do
       {:ok, new(plan)}
@@ -109,7 +108,7 @@ defmodule Braintree.Plan do
 
       {:error, :not_found} = Braintree.Plan.find("non-existing plan_id")
   """
-  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(String.t(), map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, %{"plan" => plan}} <- HTTP.put("plans/#{id}", %{plan: params}, opts) do
       {:ok, new(plan)}
@@ -121,7 +120,7 @@ defmodule Braintree.Plan do
   A plan can't be deleted if it has any former or current subscriptions associated with it.
   If there is no plan with the specified id, `{:error, :not_found}` is returned.
   """
-  @spec delete(String.t(), Keyword.t()) :: :ok | {:error, Error.t()}
+  @spec delete(String.t(), Keyword.t()) :: :ok | HTTP.error()
   def delete(id, opts \\ []) when is_binary(id) do
     with {:ok, _response} <- HTTP.delete("plans/#{id}", opts) do
       :ok

--- a/lib/search.ex
+++ b/lib/search.ex
@@ -6,7 +6,6 @@ defmodule Braintree.Search do
   https://developers.braintreepayments.com/reference/general/searching/search-fields/ruby
   """
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @doc """
@@ -18,7 +17,7 @@ defmodule Braintree.Search do
     {:ok, customers} = Braintree.Search.perform(search_params, "customers", &Braintree.Customer.new/1)
 
   """
-  @spec perform(map, String.t(), fun(), Keyword.t()) :: {:ok, [any]} | {:error, :not_found | Error.t()}
+  @spec perform(map, String.t(), fun(), Keyword.t()) :: {:ok, [any]} | HTTP.error()
   def perform(params, resource, initializer, opts \\ []) when is_map(params) do
     with {:ok, payload} <- HTTP.post(resource <> "/advanced_search_ids", %{search: params}, opts) do
       fetch_all_records(payload, resource, initializer, opts)

--- a/lib/settlement_batch_summary.ex
+++ b/lib/settlement_batch_summary.ex
@@ -11,7 +11,6 @@ defmodule Braintree.SettlementBatchSummary do
 
   import Braintree.Util, only: [atomize: 1]
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   defmodule Record do
@@ -65,7 +64,7 @@ defmodule Braintree.SettlementBatchSummary do
 
       Braintree.SettlementBatchSummary("2016-9-5", "custom_field_1")
   """
-  @spec generate(binary, binary | nil, Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec generate(binary, binary | nil, Keyword.t()) :: {:ok, [t]} | HTTP.error()
   def generate(settlement_date, custom_field \\ nil, opts \\ []) do
     criteria = build_criteria(settlement_date, custom_field)
     params = %{settlement_batch_summary: criteria}

--- a/lib/subscription.ex
+++ b/lib/subscription.ex
@@ -8,7 +8,6 @@ defmodule Braintree.Subscription do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.{AddOn, HTTP, Search, Transaction}
 
   @type t :: %__MODULE__{
@@ -86,7 +85,7 @@ defmodule Braintree.Subscription do
         plan_id: "starter"
       })
   """
-  @spec create(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec create(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("subscriptions", %{subscription: params}, opts) do
       {:ok, new(payload)}
@@ -100,7 +99,7 @@ defmodule Braintree.Subscription do
 
       {:ok, subscription} = Subscription.find("123")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(subscription_id, opts \\ []) do
     with {:ok, payload} <- HTTP.get("subscriptions/#{subscription_id}", opts) do
       {:ok, new(payload)}
@@ -115,7 +114,7 @@ defmodule Braintree.Subscription do
 
       {:ok, subscription} = Subscription.cancel("123")
   """
-  @spec cancel(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec cancel(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def cancel(subscription_id, opts \\ []) do
     with {:ok, payload} <- HTTP.put("subscriptions/#{subscription_id}/cancel", opts) do
       {:ok, new(payload)}
@@ -140,7 +139,7 @@ defmodule Braintree.Subscription do
   """
   @spec retry_charge(String.t()) :: {:ok, Transaction.t()}
   @spec retry_charge(String.t(), String.t() | nil, Keyword.t()) ::
-          {:ok, Transaction.t()} | {:error, Error.t()}
+          {:ok, Transaction.t()} | HTTP.error()
   def retry_charge(subscription_id, amount \\ nil, opts \\ []) do
     Transaction.sale(%{amount: amount, subscription_id: subscription_id}, opts)
   end
@@ -157,7 +156,7 @@ defmodule Braintree.Subscription do
       })
       subscription.plan_id # "new_plan_id"
   """
-  @spec update(binary, map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec update(binary, map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def update(id, params, opts \\ []) when is_binary(id) and is_map(params) do
     with {:ok, payload} <- HTTP.put("subscriptions/" <> id, %{subscription: params}, opts) do
       {:ok, new(payload)}
@@ -171,7 +170,7 @@ defmodule Braintree.Subscription do
 
     {:ok, subscriptions} = Braintree.Subscription.search(%{plan_id: %{is: "starter"}})
   """
-  @spec search(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec search(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def search(params, opts \\ []) when is_map(params) do
     Search.perform(params, "subscriptions", &new/1, opts)
   end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -68,7 +68,7 @@ defmodule Braintree.Transaction do
 
   defstruct add_ons: [],
             additional_processor_response: nil,
-            amount: 0,
+            amount: "0",
             android_pay_card: nil,
             apple_pay: nil,
             avs_error_response_code: nil,

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -11,7 +11,6 @@ defmodule Braintree.Transaction do
   use Braintree.Construction
 
   alias Braintree.{AddOn, HTTP}
-  alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
           add_ons: [AddOn.t()],
@@ -133,7 +132,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "settling"
   """
-  @spec sale(map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec sale(map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def sale(params, opts \\ []) do
     sale_params = Map.merge(params, %{type: "sale"})
 
@@ -151,7 +150,7 @@ defmodule Braintree.Transaction do
       {:ok, transaction} = Transaction.submit_for_settlement("123", %{amount: "100"})
       transaction.status # "settling"
   """
-  @spec submit_for_settlement(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec submit_for_settlement(String.t(), map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def submit_for_settlement(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/submit_for_settlement"
 
@@ -170,7 +169,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "refunded"
   """
-  @spec refund(String.t(), map, Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec refund(String.t(), map, Keyword.t()) :: {:ok, t} | HTTP.error()
   def refund(transaction_id, params, opts \\ []) do
     path = "transactions/#{transaction_id}/refund"
 
@@ -188,7 +187,7 @@ defmodule Braintree.Transaction do
 
       transaction.status # "voided"
   """
-  @spec void(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec void(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def void(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}/void"
 
@@ -204,7 +203,7 @@ defmodule Braintree.Transaction do
 
       {:ok, transaction} = Transaction.find("123")
   """
-  @spec find(String.t(), Keyword.t()) :: {:ok, t} | {:error, Error.t()}
+  @spec find(String.t(), Keyword.t()) :: {:ok, t} | HTTP.error()
   def find(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}"
 

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -15,7 +15,7 @@ defmodule Braintree.Transaction do
   @type t :: %__MODULE__{
           add_ons: [AddOn.t()],
           additional_processor_response: String.t(),
-          amount: number,
+          amount: String.t(),
           android_pay_card: map,
           apple_pay: map,
           avs_error_response_code: String.t(),

--- a/lib/transaction_line_item.ex
+++ b/lib/transaction_line_item.ex
@@ -7,7 +7,6 @@ defmodule Braintree.TransactionLineItem do
 
   use Braintree.Construction
 
-  alias Braintree.ErrorResponse, as: Error
   alias Braintree.HTTP
 
   @type t :: %__MODULE__{
@@ -47,7 +46,7 @@ defmodule Braintree.TransactionLineItem do
 
       {:ok, transaction_line_items} = TransactionLineItem.find("123")
   """
-  @spec find_all(String.t(), Keyword.t()) :: {:ok, [t]} | {:error, Error.t()}
+  @spec find_all(String.t(), Keyword.t()) :: {:ok, [t]} | HTTP.error()
   def find_all(transaction_id, opts \\ []) do
     path = "transactions/#{transaction_id}/line_items"
 


### PR DESCRIPTION
After my last PR I realized that specs for all functions that return an error from the HTTP module have the same issue as `Braintree.ClientToken`. This update them so that in one's app you can do something like below without a dialyzer error.

This also fixes the typespec for `Transaction.amount` since it returns a string, not an int or float.

```elixir
case Braintree.Customer.find("ima-cool-user") do
  {:ok, _customer} = response ->
    response

  {:error, :not_found} -> 
    # This is expected so don't log anything.
    {:error, :not_found}

  {:error, reason} = error ->
    # Whoops!
    Logger.error("Braintree.Customer.find/2 Error: #{inspect(reason)}")
    error
end
```

TL;DR - It fixes this for all modules that return the HTTP error.

```
The pattern can never match the type.

Pattern:
{:error, :not_found}

Type:

  {:error,
   %Braintree.ErrorResponse{
     :errors => map(),
     :message => binary(),
     :params => map(),
     :transaction => map()
   }}
```