### PR TITLE
[PATCH] Support common 5XX http statuses

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -53,6 +53,8 @@ defmodule Braintree.HTTP do
     426 => :upgrade_required,
     429 => :too_many_requests,
     500 => :server_error,
+    501 => :not_implemented,
+    502 => :bad_gateway,
     503 => :service_unavailable,
     504 => :connect_timeout
   }

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -188,6 +188,28 @@ defmodule Braintree.HTTPTest do
     end
   end
 
+  describe "code_to_reason/1" do
+    test "supports common HTTP statuses" do
+      for {status, reason} <- [
+            {400, :bad_request},
+            {401, :unauthorized},
+            {403, :forbidden},
+            {404, :not_found},
+            {406, :not_acceptable},
+            {422, :unprocessable_entity},
+            {426, :upgrade_required},
+            {429, :too_many_requests},
+            {500, :server_error},
+            {501, :not_implemented},
+            {502, :bad_gateway},
+            {503, :service_unavailable},
+            {504, :connect_timeout}
+          ] do
+        assert HTTP.code_to_reason(status) == reason
+      end
+    end
+  end
+
   defp compress(string), do: :zlib.gzip(string)
 
   defp assert_config_error(key, fun) do


### PR DESCRIPTION
Braintree experienced an outtage over the weekend and we received 502 errors. The library doesn't support that so `HTTP.code_to_reason/1` raised a FunctionClauseError `no function clause matching in Braintree.HTTP.code_to_reason/1`