### PR TITLE
[DEV] Update XML tests to eliminate false failures

### DIFF
--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -46,8 +46,11 @@ defmodule Braintree.HTTPTest do
   test "encode_body/1 converts the request body to xml" do
     params = %{company: "Soren", first_name: "Parker"}
 
-    assert HTTP.encode_body(params) ==
-             ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<company>Soren</company>\n<first-name>Parker</first-name>|
+    assert [xml_tag | nodes] = params |> HTTP.encode_body() |> String.split("\n")
+
+    assert xml_tag == ~s|<?xml version="1.0" encoding="UTF-8" ?>|
+    assert ~s|<company>Soren</company>| in nodes
+    assert ~s|<first-name>Parker</first-name>| in nodes
   end
 
   test "encode_body/1 ignores empty bodies" do


### PR DESCRIPTION
I noticed that some XML tests are failing sometimes. Iterating on maps doesn't guarantee order so the generated XML nodes aren't always in the same order. This updates those tests to assert the XML is generated as expected but node order won't cause a test failure.