### PR TITLE
Clean up unused timeout: 30_000 option from http_options in env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,6 @@ defmodule Braintree.Mixfile do
       extra_applications: [:logger, :xmerl, :telemetry],
       env: [
         environment: :sandbox,
-        http_options: [timeout: 30_000],
         master_merchant_id: {:system, "BRAINTREE_MASTER_MERCHANT_ID"},
         merchant_id: {:system, "BRAINTREE_MERCHANT_ID"},
         private_key: {:system, "BRAINTREE_PRIVATE_KEY"},


### PR DESCRIPTION
See also https://github.com/sorentwo/braintree-elixir/issues/226